### PR TITLE
Feature: switch to ScalaCheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.class
 *.log
+target/
+*/target/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # dumb-onion-hax
 High end hax for dominions 6 maps.
 
+Built on the Typelevel stack with Cats, FS2, Log4cats, and property-based tests via ScalaCheck.
+
+See [documentation/engineering/architecture/project_structure.md](documentation/engineering/architecture/project_structure.md) for the module layout and consult [AGENTS.md](AGENTS.md) before contributing.
+
 
 ## License
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,5 @@
+# Apps Module
+
+Command line tools built on the map editing model.
+
+See [../AGENTS.md](../AGENTS.md) for contribution guidelines.

--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/HelloApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/HelloApp.scala
@@ -1,6 +1,6 @@
-package example
+package com.crib.bills.dom6maps.apps
 
-object Hello extends Greeting with App {
+object HelloApp extends Greeting with App {
   println(greeting)
 }
 

--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorApp.scala
@@ -1,0 +1,7 @@
+package com.crib.bills.dom6maps.apps
+
+import com.crib.bills.dom6maps.model.Province
+
+object MapEditorApp extends App {
+  println(Province(0, "Example Province"))
+}

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/HelloAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/HelloAppSpec.scala
@@ -1,0 +1,8 @@
+package com.crib.bills.dom6maps.apps
+
+import org.scalacheck.Properties
+
+object HelloAppSpec extends Properties("HelloApp") {
+  property("greeting is hello") =
+    HelloApp.greeting == "hello"
+}

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorAppSpec.scala
@@ -1,0 +1,7 @@
+package com.crib.bills.dom6maps.apps
+
+import org.scalacheck.Properties
+
+object MapEditorAppSpec extends Properties("MapEditorApp") {
+  property("app runs") = true
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,36 @@
-import Dependencies._
+import Dependencies.*
+import sbt.Keys.*
+
+val idePackagePrefix = settingKey[Option[String]]("IDE package prefix")
 
 ThisBuild / scalaVersion := "3.4.2"
-ThisBuild / version          := "0.1.0-SNAPSHOT"
-ThisBuild / organization     := "com.crib.bills"
-ThisBuild / organizationName := "bills crib"
+ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / organization := "com.crib.bills"
+ThisBuild / organizationName := "Bill's Crib"
+Global / excludeLintKeys := Set(idePackagePrefix)
 
-lazy val root = (project in file("."))
+lazy val commonSettings = Seq(
+  idePackagePrefix := Some("com.crib.bills.dom6maps"),
+  testFrameworks += new TestFramework("org.scalacheck.ScalaCheckFramework")
+)
+
+lazy val model = (project in file("model"))
   .settings(
-    name := "dumb-onion-hax",
+    name := "model",
+    libraryDependencies ++= Dependencies.core,
+    commonSettings
   )
 
-// See https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html for instructions on how to publish to Sonatype.
+lazy val apps = (project in file("apps"))
+  .dependsOn(model)
+  .settings(
+    name := "apps",
+    libraryDependencies ++= Dependencies.tests.map(_ % Test) ++ Dependencies.apps,
+    commonSettings
+  )
+
+lazy val root = (project in file("."))
+  .aggregate(model, apps)
+  .settings(
+    name := "dumb-onion-hax"
+  )

--- a/documentation/engineering/architecture/README.md
+++ b/documentation/engineering/architecture/README.md
@@ -16,3 +16,4 @@ Item 2, the effect patterns are mandatory reading if you plan on writing code. I
 7. [Testing Strategies](testing_strategies.md) – [Full Context](../README_Architecture_And_Development_Guide.md#7-testing-strategies)
 8. [Development Workflow](development_workflow.md) – [Full Context](../README_Architecture_And_Development_Guide.md#8-development-workflow)
 9. [Tech Stack](tech_stack.md) – [Full Context](../README_Architecture_And_Development_Guide.md#9-tech-stack)
+10. [Project Structure](project_structure.md)

--- a/documentation/engineering/architecture/project_structure.md
+++ b/documentation/engineering/architecture/project_structure.md
@@ -1,0 +1,8 @@
+# Project Structure
+
+This repository is organized as a multi-module sbt build.
+
+- `model` – data types for Dominions 6 map editing.
+- `apps` – command line utilities built on the model.
+
+Refer to the root [AGENTS.md](../../AGENTS.md) for contribution guidelines and architectural references.

--- a/model/README.md
+++ b/model/README.md
@@ -1,0 +1,5 @@
+# Model Module
+
+Domain models for Dominions 6 map editing.
+
+For overall project guidance see [../AGENTS.md](../AGENTS.md).

--- a/model/src/main/scala/com/crib/bills/dom6maps/model/Province.scala
+++ b/model/src/main/scala/com/crib/bills/dom6maps/model/Province.scala
@@ -1,0 +1,3 @@
+package com.crib.bills.dom6maps.model
+
+final case class Province(id: Int, name: String)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,22 @@
 import sbt._
 
 object Dependencies {
-  lazy val munit = "org.scalameta" %% "munit" % "0.7.29"
+  private val scalacheckVersion = "1.17.0"
+  private val catsVersion       = "2.10.0"
+  private val fs2Version        = "3.10.2"
+  private val log4catsVersion   = "2.7.0"
+
+  lazy val core = Seq(
+    "org.typelevel" %% "cats-core"     % catsVersion,
+    "co.fs2"       %% "fs2-core"      % fs2Version,
+    "org.typelevel" %% "log4cats-core" % log4catsVersion
+  )
+
+  lazy val tests = Seq(
+    "org.scalacheck" %% "scalacheck" % scalacheckVersion
+  )
+
+  lazy val apps = Seq(
+    "org.typelevel" %% "log4cats-slf4j" % log4catsVersion
+  )
 }

--- a/src/test/scala/example/HelloSpec.scala
+++ b/src/test/scala/example/HelloSpec.scala
@@ -1,7 +1,0 @@
-package example
-
-class HelloSpec extends munit.FunSuite {
-  test("say hello") {
-    assertEquals(Hello.greeting, "hello")
-  }
-}


### PR DESCRIPTION
## Summary
- drop munit and add ScalaCheck test framework
- pull in Cats, FS2, and Log4cats dependencies
- document the Typelevel stack in the README

## Testing Done
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_b_68844f36737c8327b67d47329dd2464d