### PR TITLE
Fix: restore map editor tables

### DIFF
--- a/documentation/domain/dominions/manual/Dominions_Manual.md
+++ b/documentation/domain/dominions/manual/Dominions_Manual.md
@@ -37,3 +37,19 @@ This directory breaks the original manual into smaller linked sections.
   * [8.4 Uploading to Workshop](sections/8_steam_workshop.md#84-uploading-to-workshop)
   * [8.5 Important Note](sections/8_steam_workshop.md#85-important-note)
 * [9 Dominions 4 Maps](sections/9_dominions_4_maps.md)
+
+## File Guide
+
+The manual is divided into topics that serve different needs.
+
+* **Interface how-to** – using the in-game tools:
+  * [5 The Map Editor](sections/5_map_editor.md)
+  * [7 Random Map Generator](sections/7_random_map_generator.md)
+  * [8 Steam Workshop](sections/8_steam_workshop.md)
+* **Underlying mechanics** – details on map files and how the editor stores data:
+  * [4 The Map Image File](sections/4_map_image_file.md)
+  * [6 The Map File Commands](sections/6_map_file_commands/README.md)
+* **Reference tables** – directives and number lists useful while editing:
+  * [6.4 Terrain Type in the Map File](sections/6_map_file_commands/6.4_terrain_type_in_the_map_file.md)
+  * [6.5 Advanced Map Commands](sections/6_map_file_commands/6.5_advanced_map_commands.md)
+  * [6.7 Province Commands](sections/6_map_file_commands/6.7_province_commands.md)

--- a/documentation/domain/dominions/manual/sections/6_map_file_commands/6.4_terrain_type_in_the_map_file.md
+++ b/documentation/domain/dominions/manual/sections/6_map_file_commands/6.4_terrain_type_in_the_map_file.md
@@ -1,202 +1,50 @@
 6.4 Terrain Type in the Map File
 --------------------------------
 
-**#terrain <province nbr> <terrain mask>**  
+**#terrain <province nbr> <terrain mask>**
 Sets the terrain of a province. The terrain is calculated by adding certain numbers for different terrain types or other attributes.
 
-Common Terrain Masks
-
-2-pow
-
-Number
-
-Terrain
-
-\-
-
-0
-
-Plains
-
-0
-
-1
-
-Small Province
-
-1
-
-2
-
-Large Province
-
-2
-
-4
-
-Sea
-
-3
-
-8
-
-Freshwater
-
-4
-
-16
-
-Highlands (or gorge)
-
-5
-
-32
-
-Swamp
-
-6
-
-64
-
-Waste
-
-7
-
-128
-
-Forest (or kelp forest)
-
-8
-
-256
-
-Farm
-
-9
-
-512
-
-Nostart
-
-10
-
-1024
-
-Many Sites
-
-11
-
-2048
-
-Deep Sea
-
-12
-
-4096
-
-Cave
-
-22
-
-4194304
-
-Mountains
-
-24
-
-16777216
-
-Good throne location
-
-25
-
-33554432
-
-Good start location
-
-26
-
-67108864
-
-Bad throne location
-
-29
-
-536870912
-
-Warmer
-
-30
-
-1073741824
-
-Colder
-
-Rare Terrain Masks
-
-2-pow
-
-Number
-
-Terrain
-
-13
-
-8192
-
-Fire sites
-
-14
-
-16384
-
-Air sites
-
-15
-
-32768
-
-Water sites
-
-16
-
-65536
-
-Earth sites
-
-17
-
-131072
-
-Astral sites
-
-18
-
-262144
-
-Death sites
-
-19
-
-524288
-
-Nature sites
-
-20
-
-1048576
-
-Blood sites
-
-21
-
-2097152
-
-Holy sites
+### Common Terrain Masks
+
+| 2^pow | Number | Terrain |
+|-------|-------|---------------------------|
+| - | 0 | Plains |
+| 0 | 1 | Small Province |
+| 1 | 2 | Large Province |
+| 2 | 4 | Sea |
+| 3 | 8 | Freshwater |
+| 4 | 16 | Highlands (or gorge) |
+| 5 | 32 | Swamp |
+| 6 | 64 | Waste |
+| 7 | 128 | Forest (or kelp forest) |
+| 8 | 256 | Farm |
+| 9 | 512 | Nostart |
+| 10 | 1024 | Many Sites |
+| 11 | 2048 | Deep Sea |
+| 12 | 4096 | Cave |
+| 22 | 4194304 | Mountains |
+| 24 | 16777216 | Good throne location |
+| 25 | 33554432 | Good start location |
+| 26 | 67108864 | Bad throne location |
+| 29 | 536870912 | Warmer |
+| 30 | 1073741824 | Colder |
+
+### Rare Terrain Masks
+
+| 2^pow | Number | Terrain |
+|-------|-------|-----------|
+| 13 | 8192 | Fire sites |
+| 14 | 16384 | Air sites |
+| 15 | 32768 | Water sites |
+| 16 | 65536 | Earth sites |
+| 17 | 131072 | Astral sites |
+| 18 | 262144 | Death sites |
+| 19 | 524288 | Nature sites |
+| 20 | 1048576 | Blood sites |
+| 21 | 2097152 | Holy sites |
 
 You should use the map editor to set the terrain values as it would be very difficult to do it by hand.
 
 Basic terrain masks are listed in tables Common Terrain Masks and Rare Terrain Masks. Note that the terrain masks used in editing maps are NOT the same as the terrain masks in the Modding Manual that are used for modding magic sites. All terrain masks listed in the Common Terrain Masks table can be set from the map editor.
 
 The terrain masks in the Rare Terrain Masks table cannot be added from the map editor and you must add them to the base terrain mask calculated by the map editor. The advanced terrain masks make it more likely that when a magic site is placed in the province, it will be of that specific type.
-

--- a/documentation/domain/dominions/manual/sections/6_map_file_commands/6.5_advanced_map_commands.md
+++ b/documentation/domain/dominions/manual/sections/6_map_file_commands/6.5_advanced_map_commands.md
@@ -23,603 +23,116 @@ Makes this nation one of the allowed nations to play on this map. Use this comma
 
 Early Era Nations
 
-Number
-
-Nation
-
-Epithet
-
-5
-
-Arcoscephale
-
-Golden Era
-
-6
-
-Ermor
-
-New Faith
-
-7
-
-Ulm Enig
-
-ma of Steel
-
-8
-
-Marverni
-
-Time of Druids
-
-9
-
-Sauromatia
-
-Amazon Queens
-
-10
-
-T’ien Ch’i
-
-Spring and Autumn
-
-11
-
-Machaka
-
-Lion Kings
-
-12
-
-Mictlan
-
-Reign of Blood
-
-13
-
-Abysia
-
-Children of Flame
-
-14
-
-Caelum
-
-Eagle Kings
-
-15
-
-C’tis
-
-Lizard Kings
-
-16
-
-Pangaea
-
-Age of Revelry
-
-17
-
-Agartha
-
-Pale Ones
-
-18
-
-Tir na n’Og
-
-Land of the Ever Young
-
-19
-
-Fomoria
-
-The Cursed Ones
-
-20
-
-Vanheim
-
-Age of Vanir
-
-21
-
-Helheim
-
-Dusk and Death
-
-22
-
-Niefelheim
-
-Sons of Winter
-
-25
-
-Kailasa
-
-Rise of the Ape Kings
-
-26
-
-Lanka
-
-Land of Demons
-
-27
-
-Yomi
-
-Oni Kings
-
-28
-
-Hinnom
-
-Sons of the Fallen
-
-29
-
-Ur The
-
-First City
-
-30
-
-Berytos
-
-Phoenix Empire
-
-31
-
-Xibalba
-
-Vigil of the Sun
-
-36
-
-Atlantis
-
-Emergence of the Deep Ones
-
-37
-
-R’lyeh
-
-Time of Aboleths
-
-38
-
-Pelagia
-
-Pearl Kings
-
-39
-
-Oceania
-
-Coming of the Capricorns
-
-40
-
-Therodos
-
-Telkhine Spectre
-
+| Number | Nation | Epithet |
+|-------:|-----------------|------------------------|
+| 5 | Arcoscephale | Golden Era |
+| 6 | Ermor | New Faith |
+| 7 | Ulm | Enigma of Steel |
+| 8 | Marverni | Time of Druids |
+| 9 | Sauromatia | Amazon Queens |
+|10 | T’ien Ch’i | Spring and Autumn |
+|11 | Machaka | Lion Kings |
+|12 | Mictlan | Reign of Blood |
+|13 | Abysia | Children of Flame |
+|14 | Caelum | Eagle Kings |
+|15 | C’tis | Lizard Kings |
+|16 | Pangaea | Age of Revelry |
+|17 | Agartha | Pale Ones |
+|18 | Tir na n’Og | Land of the Ever Young |
+|19 | Fomoria | The Cursed Ones |
+|20 | Vanheim | Age of Vanir |
+|21 | Helheim | Dusk and Death |
+|22 | Niefelheim | Sons of Winter |
+|25 | Kailasa | Rise of the Ape Kings |
+|26 | Lanka | Land of Demons |
+|27 | Yomi | Oni Kings |
+|28 | Hinnom | Sons of the Fallen |
+|29 | Ur | The First City |
+|30 | Berytos | Phoenix Empire |
+|31 | Xibalba | Vigil of the Sun |
+|36 | Atlantis | Emergence of the Deep Ones |
+|37 | R’lyeh | Time of Aboleths |
+|38 | Pelagia | Pearl Kings |
+|39 | Oceania | Coming of the Capricorns |
+|40 | Therodos | Telkhine Spectre |
 Middle Era Nations
 
-Number
-
-Nation
-
-Epithet
-
-43
-
-Arcoscephale
-
-The Old Kingdom
-
-44
-
-Ermor
-
-Ashen Empire
-
-45
-
-Sceleria
-
-Reformed Empire
-
-46
-
-Pythium
-
-Emerald Empire
-
-47
-
-Man Towe
-
-r of Avalon
-
-48
-
-Eriu
-
-Last of the Tuatha
-
-49
-
-Ulm Forg
-
-es of Ulm
-
-50
-
-Marignon
-
-Fiery Justice
-
-51
-
-Mictlan
-
-Reign of the Lawgiver
-
-52
-
-T’ien Ch’i
-
-Imperial Bureaucracy
-
-53
-
-Machaka
-
-Reign of Sorcerors
-
-54
-
-Agartha
-
-Golem Cult
-
-55
-
-Abysia
-
-Blood and Fire
-
-56
-
-Caelum
-
-Reign of the Seraphim
-
-57
-
-C’tis
-
-Miasma
-
-58
-
-Pangaea
-
-Age of Bronze
-
-59
-
-Asphodel
-
-Carrion Woods
-
-60
-
-Vanheim
-
-Arrival of Man
-
-61
-
-Jotunheim
-
-Iron Woods
-
-62
-
-Vanarus
-
-Land of the Chuds
-
-63
-
-Bandar Log
-
-Land of the Apes
-
-64
-
-Shinuyama
-
-Land of the Bakemono
-
-65
-
-Ashdod
-
-Reign of the Anakim
-
-66
-
-Uruk
-
-City States
-
-67
-
-Nazca
-
-Kingdom of the Sun
-
-68
-
-Xibalba
-
-Flooded Caves
-
-73
-
-Atlantis
-
-Kings of the Deep
-
-74
-
-R’lyeh
-
-Fallen Star
-
-75
-
-Pelagia
-
-Triton Kings
-
-76
-
-Oceania
-
-Mermidons
-
-77
-
-Ys Morg
-
-en Queens
-
+| Number | Nation | Epithet |
+|-------:|-----------------|----------------------|
+|43 | Arcoscephale | The Old Kingdom |
+|44 | Ermor | Ashen Empire |
+|45 | Sceleria | Reformed Empire |
+|46 | Pythium | Emerald Empire |
+|47 | Man | Tower of Avalon |
+|48 | Eriu | Last of the Tuatha |
+|49 | Ulm | Forges of Ulm |
+|50 | Marignon | Fiery Justice |
+|51 | Mictlan | Reign of the Lawgiver |
+|52 | T’ien Ch’i | Imperial Bureaucracy |
+|53 | Machaka | Reign of Sorcerors |
+|54 | Agartha | Golem Cult |
+|55 | Abysia | Blood and Fire |
+|56 | Caelum | Reign of the Seraphim |
+|57 | C’tis | Miasma |
+|58 | Pangaea | Age of Bronze |
+|59 | Asphodel | Carrion Woods |
+|60 | Vanheim | Arrival of Man |
+|61 | Jotunheim | Iron Woods |
+|62 | Vanarus | Land of the Chuds |
+|63 | Bandar Log | Land of the Apes |
+|64 | Shinuyama | Land of the Bakemono |
+|65 | Ashdod | Reign of the Anakim |
+|66 | Uruk | City States |
+|67 | Nazca | Kingdom of the Sun |
+|68 | Xibalba | Flooded Caves |
+|73 | Atlantis | Kings of the Deep |
+|74 | R’lyeh | Fallen Star |
+|75 | Pelagia | Triton Kings |
+|76 | Oceania | Mermidons |
+|77 | Ys | Morgen Queens |
 Late Era Nations
 
-Number
-
-Nation
-
-Epithet
-
-80
-
-Arcoscephale
-
-Sibylline Guidance
-
-81
-
-Pythium
-
-Serpent Cult
-
-82
-
-Lemur
-
-Soul Gate
-
-83
-
-Man
-
-Towers of Chelms
-
-84
-
-Ulm
-
-Black Forest
-
-85
-
-Marignon
-
-Conquerors of the Sea
-
-86
-
-Mictlan
-
-Blood and Rain
-
-87
-
-T’ien Ch’i
-
-Barbarian Kings
-
-89
-
-Jomon
-
-Human Daimyos
-
-90
-
-Agartha
-
-Ktonian Dead
-
-91
-
-Abysia
-
-Blood of Humans
-
-92
-
-Caelum
-
-Return of the Raptors
-
-93
-
-C’tis
-
-Desert Tombs
-
-94
-
-Pangaea
-
-New Era
-
-95
-
-Midgård
-
-Age of Men
-
-96
-
-Utgård
-
-Well of Urd
-
-97
-
-Bogarus
-
-Age of Heroes
-
-98
-
-Patala
-
-Reign of the Nagas
-
-99
-
-Gath
-
-Last of the Giants
-
-100
-
-Ragha
-
-Dual Kingdom
-
-101
-
-Xibalba
-
-Return of the Zotz
-
-106
-
-Atlantis
-
-Frozen Sea
-
-107
-
-R’lyeh
-
-Dreamlands
-
-108
-
-Erytheia
-
-Kingdom of Two Worlds
-
+| Number | Nation | Epithet |
+|-------:|-----------------|-----------------------|
+|80 | Arcoscephale | Sibylline Guidance |
+|81 | Pythium | Serpent Cult |
+|82 | Lemuria | Soul Gate |
+|83 | Man | Towers of Chelms |
+|84 | Ulm | Black Forest |
+|85 | Marignon | Conquerors of the Sea |
+|86 | Mictlan | Blood and Rain |
+|87 | T’ien Ch’i | Barbarian Kings |
+|89 | Jomon | Human Daimyos |
+|90 | Agartha | Ktonian Dead |
+|91 | Abysia | Blood of Humans |
+|92 | Caelum | Return of the Raptors |
+|93 | C’tis | Desert Tombs |
+|94 | Pangaea | New Era |
+|95 | Midgård | Age of Men |
+|96 | Utgård | Well of Urd |
+|97 | Bogarus | Age of Heroes |
+|98 | Patala | Reign of the Nagas |
+|99 | Gath | Last of the Giants |
+|100 | Ragha | Dual Kingdom |
+|101 | Xibalba | Return of the Zotz |
+|106 | Atlantis | Frozen Sea |
+|107 | R’lyeh | Dreamlands |
+|108 | Erytheia | Kingdom of Two Worlds |
 Special Nations
 
-Number
-
-Nation
-
-Note
-
-0
-
-Independents
-
-2
-
-Special Independents
-
-e.g. Horrors
-
-**#computerplayer <nation nbr> <difficulty>**  
-This nation will always be controlled by the computer. Difficulty ranges from one to five. One is Easy AI. Two is Standard difficulty, followed by Difficult (3), Mighty (4) and Impossible (5) AI.
-
-**#allies <nation nbr> <nation nbr>**  
-These two players will not attack each other. This command will only affect computer players.
-
-**#victorycondition <condition> <attribute>**  
-The game will end when one player fulfills a special condition, see table Victory Conditions. Dominion score is 11-20 points per converted province, depending on the strength of the dominion. The value of ‘condition’ should be a number from 0 to 6.
-
+| Number | Nation | Note |
+|-------:|---------------------|----------------|
+|0 | Independents | |
+|2 | Special Independents | e.g. Horrors |
 Victory Conditions
 
-Number
-
-Condition
-
-Attribute
-
-0
-
-Standard
-
-Nothing
-
-2
-
-Dominion
-
-Dominion score req.
-
-3
-
-Provinces
-
-Provinces required
-
-4
-
-Research
-
-Research points req.
-
-6
-
-Thrones
-
-Nbr of Ascension Points
-
+| Number | Condition | Attribute |
+|-------:|-----------|----------------------|
+|0 | Standard | Nothing |
+|2 | Dominion | Dominion score req. |
+|3 | Provinces | Provinces required |
+|4 | Research | Research points req. |
+|6 | Thrones | Nbr of Ascension Points |
 **#cannotwin <nation nbr>**  
 This nation will not win when they fulfill a special victory condition.
 

--- a/documentation/domain/dominions/manual/sections/6_map_file_commands/6.7_province_commands.md
+++ b/documentation/domain/dominions/manual/sections/6_map_file_commands/6.7_province_commands.md
@@ -15,439 +15,114 @@ Sets the population type of the active province. This determines which troops ma
 
 Poptypes
 
-Number
-
-Poptype
-
-25
-
-Barbarians
-
-26
-
-Horse Tribe
-
-27
-
-Militia, Archers, Hvy Inf
-
-28
-
-Militia, Archers, Hvy Inf
-
-29
-
-Militia, Archers, Hvy Inf
-
-30
-
-Militia, Longbow, Knight
-
-31
-
-Tritons
-
-32
-
-Lt Inf, Hvy Inf, X-Bow
-
-33
-
-Lt Inf, Hvy Inf, X-Bow
-
-34
-
-Raptors
-
-35
-
-Slingers
-
-36
-
-Lizards
-
-37
-
-Woodsmen
-
-38
-
-Hoburg
-
-39
-
-Militia, Archers, Lt Inf
-
-40
-
-Amazon, Crystal
-
-41
-
-Amazon, Garnet
-
-42
-
-Amazon, Jade
-
-43
-
-Amazon, Onyx
-
-44
-
-Troglodytes
-
-45
-
-Tritons, Shark Knights
-
-46
-
-Amber Clan Tritons
-
-47
-
-X-Bow, Hvy Cavalry
-
-48
-
-Militia, Lt Inf, Hvy Inf
-
-49
-
-Militia, Lt Inf, Hvy Inf
-
-50
-
-Militia, Lt Inf, Hvy Inf
-
-51
-
-Militia, Lt Cav, Hvy Cav
-
-52
-
-Militia, Lt Cav, Hvy Cav
-
-53
-
-Militia, Lt Cav, Hvy Cav
-
-54
-
-Hvy Inf, Hvy Cavalry
-
-55
-
-Hvy Inf, Hvy Cavalry
-
-56
-
-Hvy Inf, Hvy Cavalry
-
-57
-
-Shamblers
-
-58
-
-Lt Inf, Hvy Inf, X-Bow
-
-59
-
-Militia, Lt Inf, Archers
-
-60
-
-Militia, Lt Inf, Archers
-
-61
-
-Vaettir, Trolls
-
-62
-
-Tribals, Deer
-
-63
-
-Tritons
-
-64
-
-Tritons
-
-65
-
-Ichtyids
-
-66
-
-Vaettir
-
-67
-
-Vaettir, Dwarven Smith
-
-68
-
-Slingers, Hvy Inf, Elephants
-
-69
-
-Asmeg
-
-70
-
-Vaettir, Svartalf
-
-71
-
-Trolls
-
-72
-
-Mermen
-
-73
-
-Tritons, Triton Knights
-
-74
-
-Lt Inf, Lt Cav, Cataphracts
-
-75
-
-Hoburg, LA
-
-76
-
-Hoburg, EA
-
-77
-
-Atavi Apes
-
-78
-
-Tribals, Wolf
-
-79
-
-Tribals, Bear
-
-80
-
-Tribals, Lion
-
-81
-
-Pale Ones
-
-82
-
-Tribals, Jaguar
-
-83
-
-Tribals, Toad
-
-84
-
-Cavemen
-
-85
-
-Kappa
-
-86
-
-Bakemono
-
-87
-
-Bakemono
-
-88
-
-Ko-Oni
-
-89
-
-Fir Bolg
-
-90
-
-Turtle Tribe Tritons
-
-91
-
-Shark Tribe Tritons
-
-92
-
-Shark Tribe, Shark Riders
-
-93
-
-Zotz
-
-94
-
-Lava-born
-
-95
-
-Ichtyid Shaman
-
-96
-
-Bone Tribe
-
-97
-
-Merrow
-
-98
-
-Kulullu
-
-**#owner <nation nbr>**  
-Changes the ownership of the active province. Nation nbr indicates the new owner. Nation numbers can be found in the Early Era Nations table and the three following tables.
-
-**#killfeatures**  
-Removes all magic sites from the active province.
-
-**#feature “<site name>” | <site nbr>**  
-Puts a specific magic site in the active province. This command can be used a maximum of eight times per province, because that is the maximum number of sites a province can have. Adding unique sites to a map using this command will NOT prevent those sites from appearing randomly, because the map file is only applied to the game map after game setup has done random determination of sites for each province. If the #killfeatures command was not used and all site slots were already filled by randomly determined sites during game setup, this command will be ignored and the site won’t appear. These same limitations apply to the following command:
-
-**#knownfeature “<site name>” | <site nbr>**  
-Puts a specific magic site in the active province. This site is already found at the start of the game, regardless of its ordinary path level. Using this command prevents special features of the site that depend on its discovery from activating. For example, the magic site Academy of High Magics normally causes a laboratory to be built in the province upon discovery, but if the site is set by this command, the #lab command must be used to add a laboratory to the province. Otherwise the owner of the province must build the laboratory as normal and pay the gold cost.
-
-**#fort <fort nbr>**  
-Puts a specific fort in the active province. Fort nbr is a number between 1 and 29 and the list of fort numbers can be found in the Fortifications table. Will replace a nation’s default fort if used on a capital location.
-
+| Number | Poptype |
+|-------:|-------------------------------|
+| 25 | Barbarians |
+| 26 | Horse Tribe |
+| 27 | Militia, Archers, Hvy Inf |
+| 28 | Militia, Archers, Hvy Inf |
+| 29 | Militia, Archers, Hvy Inf |
+| 30 | Militia, Longbow, Knight |
+| 31 | Tritons |
+| 32 | Lt Inf, Hvy Inf, X-Bow |
+| 33 | Lt Inf, Hvy Inf, X-Bow |
+| 34 | Raptors |
+| 35 | Slingers |
+| 36 | Lizards |
+| 37 | Woodsmen |
+| 38 | Hoburg |
+| 39 | Militia, Archers, Lt Inf |
+| 40 | Amazon, Crystal |
+| 41 | Amazon, Garnet |
+| 42 | Amazon, Jade |
+| 43 | Amazon, Onyx |
+| 44 | Troglodytes |
+| 45 | Tritons, Shark Knights |
+| 46 | Amber Clan Tritons |
+| 47 | X-Bow, Hvy Cavalry |
+| 48 | Militia, Lt Inf, Hvy Inf |
+| 49 | Militia, Lt Inf, Hvy Inf |
+| 50 | Militia, Lt Inf, Hvy Inf |
+| 51 | Militia, Lt Cav, Hvy Cav |
+| 52 | Militia, Lt Cav, Hvy Cav |
+| 53 | Militia, Lt Cav, Hvy Cav |
+| 54 | Hvy Inf, Hvy Cavalry |
+| 55 | Hvy Inf, Hvy Cavalry |
+| 56 | Hvy Inf, Hvy Cavalry |
+| 57 | Shamblers |
+| 58 | Lt Inf, Hvy Inf, X-Bow |
+| 59 | Militia, Lt Inf, Archers |
+| 60 | Militia, Lt Inf, Archers |
+| 61 | Vaettir, Trolls |
+| 62 | Tribals, Deer |
+| 63 | Tritons |
+| 64 | Tritons |
+| 65 | Ichtyids |
+| 66 | Vaettir |
+| 67 | Vaettir, Dwarven Smith |
+| 68 | Slingers, Hvy Inf, Elephants |
+| 69 | Asmeg |
+| 70 | Vaettir, Svartalf |
+| 71 | Trolls |
+| 72 | Mermen |
+| 73 | Tritons, Triton Knights |
+| 74 | Lt Inf, Lt Cav, Cataphracts |
+| 75 | Hoburg, LA |
+| 76 | Hoburg, EA |
+| 77 | Atavi Apes |
+| 78 | Tribals, Wolf |
+| 79 | Tribals, Bear |
+| 80 | Tribals, Lion |
+| 81 | Pale Ones |
+| 82 | Tribals, Jaguar |
+| 83 | Tribals, Toad |
+| 84 | Cavemen |
+| 85 | Kappa |
+| 86 | Bakemono |
+| 87 | Bakemono |
+| 88 | Ko-Oni |
+| 89 | Fir Bolg |
+| 90 | Turtle Tribe Tritons |
+| 91 | Shark Tribe Tritons |
+| 92 | Shark Tribe, Shark Riders |
+| 93 | Zotz |
+| 94 | Lava-born |
+| 95 | Ichtyid Shaman |
+| 96 | Bone Tribe |
+| 97 | Merrow |
+| 98 | Kulullu |
 Fortifications
 
-Number
-
-Fort
-
-1
-
-Palisades
-
-2
-
-Fortress
-
-3
-
-Castle
-
-4
-
-Citadel
-
-5
-
-Rock Walls
-
-6
-
-Fortress
-
-7
-
-Castle
-
-8
-
-Castle of Bronze and Crystal
-
-9
-
-Kelp Fort
-
-10
-
-Bramble Fort
-
-11
-
-City Palisades
-
-12
-
-Walled City
-
-13
-
-Fortified City
-
-14
-
-Great Walled City
-
-15
-
-Giant Palisades
-
-16
-
-Giant Fortress
-
-17
-
-Giant Castle
-
-18
-
-Giant Citadel
-
-19
-
-Grand Citadel
-
-20
-
-Ice Walls
-
-21
-
-Ice Fortress
-
-22
-
-Ice Castle
-
-23
-
-Ice Citadel
-
-24
-
-Wizard’s Tower
-
-25
-
-Citadel of Power
-
-27
-
-Fortified village
-
-28
-
-Wooden Fort
-
-29
-
-Crystal Citadel
-
+| Number | Fort |
+|-------:|----------------------------------|
+| 1 | Palisades |
+| 2 | Fortress |
+| 3 | Castle |
+| 4 | Citadel |
+| 5 | Rock Walls |
+| 6 | Fortress |
+| 7 | Castle |
+| 8 | Castle of Bronze and Crystal |
+| 9 | Kelp Fort |
+|10 | Bramble Fort |
+|11 | City Palisades |
+|12 | Walled City |
+|13 | Fortified City |
+|14 | Great Walled City |
+|15 | Giant Palisades |
+|16 | Giant Fortress |
+|17 | Giant Castle |
+|18 | Giant Citadel |
+|19 | Grand Citadel |
+|20 | Ice Walls |
+|21 | Ice Fortress |
+|22 | Ice Castle |
+|23 | Ice Citadel |
+|24 | Wizard's Tower |
+|25 | Citadel of Power |
+|27 | Fortified village |
+|28 | Wooden Fort |
+|29 | Crystal Citadel |
 **#temple**  
 Puts a temple in the active province.
 


### PR DESCRIPTION
## Summary
- reformat table data in the Dominions 5 map manual
- categorize manual sections in `Dominions_Manual.md`

## Testing
- `sbt -Dsbt.log.noformat=true compile`

------
https://chatgpt.com/codex/tasks/task_b_68845571504083278bddd6dd7110de70