### PR TITLE
Feature: Province Adjacency

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorApp.scala
@@ -1,7 +1,7 @@
 package com.crib.bills.dom6maps.apps
 
-import com.crib.bills.dom6maps.model.Province
+import com.crib.bills.dom6maps.model.{Province, ProvinceId}
 
 object MapEditorApp extends App {
-  println(Province(0, "Example Province"))
+  println(Province(ProvinceId(0), "Example Province"))
 }

--- a/documentation/domain/dominions/domain_model.md
+++ b/documentation/domain/dominions/domain_model.md
@@ -7,7 +7,17 @@ This document tracks data types extracted from the reference tables in the map m
 - `Nation` – all playable nations indexed by the table in the advanced map commands section.
 - `TerrainFlag` – bitmask values for terrain types.
 - `MagicType` – rare terrain masks representing magic paths.
+- `BorderFlag` – bitmask values for province borders.
+
+## Value Classes
+
+- `ProvinceId` – 1-based identifier for provinces in the map file.
 
 ## Map Directives
 
 `model.map.MapDirective` and its subclasses represent typed commands found in a `.map` file. They replace primitive arguments with small value classes to reduce errors.
+
+### Province Adjacency
+
+- `Neighbour` – standard connection between two provinces.
+- `NeighbourSpec` – connection with a `BorderFlag` describing mountain passes, rivers, impassable borders, or roads.

--- a/model/src/main/scala/model/BorderFlag.scala
+++ b/model/src/main/scala/model/BorderFlag.scala
@@ -1,0 +1,14 @@
+package com.crib.bills.dom6maps
+package model
+
+/**
+  * Bitmask values describing province borders.
+  *
+  * Mirrors the values accepted by the `#neighbourspec` command.
+  */
+enum BorderFlag(val mask: Int):
+  case Standard    extends BorderFlag(0)
+  case MountainPass extends BorderFlag(1)
+  case River       extends BorderFlag(2)
+  case Impassable  extends BorderFlag(4)
+  case Road        extends BorderFlag(8)

--- a/model/src/main/scala/model/Province.scala
+++ b/model/src/main/scala/model/Province.scala
@@ -1,4 +1,4 @@
 package com.crib.bills.dom6maps
 package model
 
-final case class Province(id: Int, name: String)
+final case class Province(id: ProvinceId, name: String)

--- a/model/src/main/scala/model/ProvinceId.scala
+++ b/model/src/main/scala/model/ProvinceId.scala
@@ -1,0 +1,5 @@
+package com.crib.bills.dom6maps
+package model
+
+/** Identifier for a province as referenced in map files. */
+final case class ProvinceId(value: Int) extends AnyVal

--- a/model/src/main/scala/model/map/MapDirective.scala
+++ b/model/src/main/scala/model/map/MapDirective.scala
@@ -19,8 +19,10 @@ final case class FloatColor(red: ColorComponent, green: ColorComponent, blue: Co
 final case class MapTextColor(color: FloatColor) extends MapDirective
 final case class MapDomColor(red: Int, green: Int, blue: Int, alpha: Int) extends MapDirective
 
-import com.crib.bills.dom6maps.model.Nation
+import com.crib.bills.dom6maps.model.{Nation, ProvinceId, BorderFlag}
 final case class AllowedPlayer(nation: Nation) extends MapDirective
-final case class SpecStart(nation: Nation, province: Int) extends MapDirective
-final case class Terrain(province: Int, mask: Int) extends MapDirective
-final case class LandName(province: Int, name: String) extends MapDirective
+final case class SpecStart(nation: Nation, province: ProvinceId) extends MapDirective
+final case class Terrain(province: ProvinceId, mask: Int) extends MapDirective
+final case class LandName(province: ProvinceId, name: String) extends MapDirective
+final case class Neighbour(a: ProvinceId, b: ProvinceId) extends MapDirective
+final case class NeighbourSpec(a: ProvinceId, b: ProvinceId, border: BorderFlag) extends MapDirective


### PR DESCRIPTION
## Summary
- model special province border flags
- add `Neighbour` and `NeighbourSpec` directives
- introduce `ProvinceId` value class and refactor directives
- document province identifier

## Testing Done
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_6885277e5c2c8327b91ccb5f3c0d5339