### PR TITLE
Fix: swap regex parser for fastparse

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
@@ -39,6 +39,7 @@ object MapFileParserSpec extends Properties("MapFileParser") {
       AllowedPlayer(Nation.Xibalba_Early),
       SpecStart(Nation.Xibalba_Early, ProvinceId(1)),
       Terrain(ProvinceId(1), 264),
+      LandName(ProvinceId(1), "Province One"),
       Neighbour(ProvinceId(1), ProvinceId(2)),
       NeighbourSpec(ProvinceId(1), ProvinceId(2), BorderFlag.MountainPass)
     )

--- a/model/src/main/scala/model/map/MapFileParser.scala
+++ b/model/src/main/scala/model/map/MapFileParser.scala
@@ -6,6 +6,8 @@ import fs2.{Pipe, Stream}
 import fs2.io.file.{Files, Path}
 import fs2.text
 import com.crib.bills.dom6maps.model.{BorderFlag, Nation, ProvinceId}
+import fastparse._
+import fastparse.NoWhitespace._
 
 object MapFileParser:
   def parseFile[Sequencer[_]: Sync](path: Path)(using Files[Sequencer]): Stream[Sequencer, MapDirective] =
@@ -19,52 +21,112 @@ object MapFileParser:
       .map(parseLine)
       .collect { case Some(directive) => directive }
 
-  private val Dom2TitleRegex     = """#dom2title\s+(.+)""".r
-  private val ImageFileRegex     = """#imagefile\s+(.+)""".r
-  private val MapSizeRegex       = """#mapsize\s+(\d+)\s+(\d+)""".r
-  private val DomVersionRegex    = """#domversion\s+(\d+)""".r
-  private val MapTextColRegex    = """#maptextcol\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)""".r
-  private val MapDomColRegex     = """#mapdomcol\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+)""".r
-  private val AllowedPlayerRegex = """#allowedplayer\s+(\d+)""".r
-  private val SpecStartRegex     = """#specstart\s+(\d+)\s+(\d+)""".r
-  private val TerrainRegex       = """#terrain\s+(\d+)\s+(\d+)""".r
-  private val LandNameRegex      = raw"""#landname\s+(\d+)\s+"([^"]+)""".r
-  private val NeighbourRegex     = """#neighbour\s+(\d+)\s+(\d+)""".r
-  private val NeighbourSpecRegex = """#neighbourspec\s+(\d+)\s+(\d+)\s+(\d+)""".r
+  private def ws[$: P]: P[Unit] = P(CharIn(" \t").rep(1))
+  private def int[$: P]: P[Int] = P(CharIn("0-9").rep(1).!.map(_.toInt))
+  private def dbl[$: P]: P[Double] = P(CharIn("0-9.").rep(1).!.map(_.toDouble))
+  private def rest[$: P]: P[String] = P(CharsWhile(_ != '\n').!.map(_.trim))
+  private def quoted[$: P]: P[String] = P("\"" ~/ CharsWhile(_ != '"').! ~ "\"")
 
-  private def parseLine(line: String): Option[MapDirective] =
-    line match
-      case Dom2TitleRegex(t)    => Some(Dom2Title(t))
-      case ImageFileRegex(f)    => Some(ImageFile(f))
-      case MapSizeRegex(w, h)   => Some(MapSize(MapWidth(w.toInt), MapHeight(h.toInt)))
-      case DomVersionRegex(v)   => Some(DomVersion(v.toInt))
-      case "#hwraparound"       => Some(HWrapAround)
-      case "#nodeepcaves"       => Some(NoDeepCaves)
-      case "#nodeepchoice"      => Some(NoDeepChoice)
-      case "#mapnohide"         => Some(MapNoHide)
-      case MapTextColRegex(r,g,b,a) =>
+  private def dom2TitleP[$: P]: P[Option[MapDirective]] =
+    P("#dom2title" ~ ws ~ rest).map(t => Some(Dom2Title(t)))
+
+  private def imageFileP[$: P]: P[Option[MapDirective]] =
+    P("#imagefile" ~ ws ~ rest).map(f => Some(ImageFile(f)))
+
+  private def mapSizeP[$: P]: P[Option[MapDirective]] =
+    P("#mapsize" ~ ws ~ int ~ ws ~ int).map { case (w, h) =>
+      Some(MapSize(MapWidth(w), MapHeight(h)))
+    }
+
+  private def domVersionP[$: P]: P[Option[MapDirective]] =
+    P("#domversion" ~ ws ~ int).map(v => Some(DomVersion(v)))
+
+  private def hwrapAroundP[$: P]: P[Option[MapDirective]] =
+    P("#hwraparound").map(_ => Some(HWrapAround))
+
+  private def nodeepcavesP[$: P]: P[Option[MapDirective]] =
+    P("#nodeepcaves").map(_ => Some(NoDeepCaves))
+
+  private def nodeepchoiceP[$: P]: P[Option[MapDirective]] =
+    P("#nodeepchoice").map(_ => Some(NoDeepChoice))
+
+  private def mapnohideP[$: P]: P[Option[MapDirective]] =
+    P("#mapnohide").map(_ => Some(MapNoHide))
+
+  private def maptextcolP[$: P]: P[Option[MapDirective]] =
+    P("#maptextcol" ~ ws ~ dbl ~ ws ~ dbl ~ ws ~ dbl ~ ws ~ dbl).map {
+      case (r, g, b, a) =>
         Some(
           MapTextColor(
             FloatColor(
-              ColorComponent(r.toDouble),
-              ColorComponent(g.toDouble),
-              ColorComponent(b.toDouble),
-              ColorComponent(a.toDouble)
+              ColorComponent(r),
+              ColorComponent(g),
+              ColorComponent(b),
+              ColorComponent(a)
             )
           )
         )
-      case MapDomColRegex(r,g,b,a) =>
-        Some(MapDomColor(r.toInt, g.toInt, b.toInt, a.toInt))
-      case AllowedPlayerRegex(n) =>
-        Nation.values.find(_.id == n.toInt).map(AllowedPlayer.apply)
-      case SpecStartRegex(n, p) =>
-        Nation.values.find(_.id == n.toInt).map(SpecStart(_, ProvinceId(p.toInt)))
-      case TerrainRegex(p, m)   => Some(Terrain(ProvinceId(p.toInt), m.toInt))
-      case LandNameRegex(p, n)  => Some(LandName(ProvinceId(p.toInt), n))
-      case NeighbourRegex(a, b) => Some(Neighbour(ProvinceId(a.toInt), ProvinceId(b.toInt)))
-      case NeighbourSpecRegex(a, b, flg) =>
+    }
+
+  private def mapdomcolP[$: P]: P[Option[MapDirective]] =
+    P("#mapdomcol" ~ ws ~ int ~ ws ~ int ~ ws ~ int ~ ws ~ int).map {
+      case (r, g, b, a) => Some(MapDomColor(r, g, b, a))
+    }
+
+  private def allowedPlayerP[$: P]: P[Option[MapDirective]] =
+    P("#allowedplayer" ~ ws ~ int).map { n =>
+      Nation.values.find(_.id == n).map(AllowedPlayer.apply)
+    }
+
+  private def specStartP[$: P]: P[Option[MapDirective]] =
+    P("#specstart" ~ ws ~ int ~ ws ~ int).map { case (n, p) =>
+      Nation.values.find(_.id == n).map(SpecStart(_, ProvinceId(p)))
+    }
+
+  private def terrainP[$: P]: P[Option[MapDirective]] =
+    P("#terrain" ~ ws ~ int ~ ws ~ int).map { case (p, m) =>
+      Some(Terrain(ProvinceId(p), m))
+    }
+
+  private def landnameP[$: P]: P[Option[MapDirective]] =
+    P("#landname" ~ ws ~ int ~ ws ~ quoted).map { case (p, n) =>
+      Some(LandName(ProvinceId(p), n))
+    }
+
+  private def neighbourP[$: P]: P[Option[MapDirective]] =
+    P("#neighbour" ~ ws ~ int ~ ws ~ int).map { case (a, b) =>
+      Some(Neighbour(ProvinceId(a), ProvinceId(b)))
+    }
+
+  private def neighbourspecP[$: P]: P[Option[MapDirective]] =
+    P("#neighbourspec" ~ ws ~ int ~ ws ~ int ~ ws ~ int).map {
+      case (a, b, flg) =>
         BorderFlag.values
-          .find(_.mask == flg.toInt)
-          .map(NeighbourSpec(ProvinceId(a.toInt), ProvinceId(b.toInt), _))
-      case _ => None
+          .find(_.mask == flg)
+          .map(NeighbourSpec(ProvinceId(a), ProvinceId(b), _))
+    }
+
+  private def directive[$: P]: P[Option[MapDirective]] = P(
+    dom2TitleP |
+      imageFileP |
+      mapSizeP |
+      domVersionP |
+      hwrapAroundP |
+      nodeepcavesP |
+      nodeepchoiceP |
+      mapnohideP |
+      maptextcolP |
+      mapdomcolP |
+      allowedPlayerP |
+      specStartP |
+      terrainP |
+      landnameP |
+      neighbourP |
+      neighbourspecP
+  )
+
+  private def parseLine(line: String): Option[MapDirective] =
+    fastparse.parse(line, p => directive(using p)) match
+      case Parsed.Success(value, _) => value
+      case _                        => None
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,12 +5,14 @@ object Dependencies {
   private val catsVersion       = "2.10.0"
   private val fs2Version        = "3.10.2"
   private val log4catsVersion   = "2.7.0"
+  private val fastparseVersion  = "3.1.1"
 
   lazy val core = Seq(
     "org.typelevel" %% "cats-core"     % catsVersion,
     "co.fs2"       %% "fs2-core"      % fs2Version,
     "co.fs2"       %% "fs2-io"        % fs2Version,
-    "org.typelevel" %% "log4cats-core" % log4catsVersion
+    "org.typelevel" %% "log4cats-core" % log4catsVersion,
+    "com.lihaoyi"  %% "fastparse"     % fastparseVersion
   )
 
   lazy val tests = Seq(


### PR DESCRIPTION
## Summary
- replace regex-based MapFileParser with fastparse implementation
- add fastparse dependency
- update expectations in MapFileParserSpec

## Testing
- `sbt "project apps" test`
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_68855d9c45648327aa66bbd0004b367b