### PR TITLE
Feature: Rendering Typeclasses

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
@@ -1,0 +1,114 @@
+package com.crib.bills.dom6maps
+
+import org.scalacheck.{Arbitrary, Gen}
+import model.*
+import model.map.*
+
+object Arbitraries:
+  given Arbitrary[Nation] =
+    Arbitrary(Gen.oneOf(Nation.values.toSeq))
+
+  given Arbitrary[ProvinceId] =
+    Arbitrary(Gen.choose(1, 5000).map(ProvinceId.apply))
+
+  given Arbitrary[BorderFlag] =
+    Arbitrary(Gen.oneOf(BorderFlag.values.toSeq))
+
+  given Arbitrary[MapWidth] =
+    Arbitrary(Gen.choose(10, 5000).map(MapWidth.apply))
+
+  given Arbitrary[MapHeight] =
+    Arbitrary(Gen.choose(10, 5000).map(MapHeight.apply))
+
+  given Arbitrary[Dom2Title] =
+    Arbitrary(Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString).map(Dom2Title.apply))
+
+  given Arbitrary[ImageFile] =
+    Arbitrary(Gen.nonEmptyListOf(Gen.alphaChar).map(n => ImageFile(s"$n.tga")))
+
+  given Arbitrary[MapSize] =
+    Arbitrary(for
+      w <- summon[Arbitrary[MapWidth]].arbitrary
+      h <- summon[Arbitrary[MapHeight]].arbitrary
+    yield MapSize(w, h))
+
+  given Arbitrary[DomVersion] =
+    Arbitrary(Gen.choose(500, 600).map(DomVersion.apply))
+
+  given Arbitrary[ColorComponent] =
+    Arbitrary(Gen.choose(0.0, 1.0).map(ColorComponent.apply))
+
+  given Arbitrary[FloatColor] =
+    Arbitrary(for
+      r <- summon[Arbitrary[ColorComponent]].arbitrary
+      g <- summon[Arbitrary[ColorComponent]].arbitrary
+      b <- summon[Arbitrary[ColorComponent]].arbitrary
+      a <- summon[Arbitrary[ColorComponent]].arbitrary
+    yield FloatColor(r, g, b, a))
+
+  given Arbitrary[MapTextColor] =
+    Arbitrary(summon[Arbitrary[FloatColor]].arbitrary.map(MapTextColor.apply))
+
+  given Arbitrary[MapDomColor] =
+    Arbitrary(for
+      r <- Gen.choose(0, 255)
+      g <- Gen.choose(0, 255)
+      b <- Gen.choose(0, 255)
+      a <- Gen.choose(0, 255)
+    yield MapDomColor(r, g, b, a))
+
+  given Arbitrary[AllowedPlayer] =
+    Arbitrary(summon[Arbitrary[Nation]].arbitrary.map(AllowedPlayer.apply))
+
+  given Arbitrary[SpecStart] =
+    Arbitrary(for
+      n <- summon[Arbitrary[Nation]].arbitrary
+      p <- summon[Arbitrary[ProvinceId]].arbitrary
+    yield SpecStart(n, p))
+
+  given Arbitrary[Terrain] =
+    Arbitrary(for
+      p <- summon[Arbitrary[ProvinceId]].arbitrary
+      m <- Gen.choose(0, Int.MaxValue)
+    yield Terrain(p, m))
+
+  given Arbitrary[LandName] =
+    Arbitrary(for
+      p <- summon[Arbitrary[ProvinceId]].arbitrary
+      n <- Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString)
+    yield LandName(p, n))
+
+  given Arbitrary[Neighbour] =
+    Arbitrary(for
+      a <- summon[Arbitrary[ProvinceId]].arbitrary
+      b <- summon[Arbitrary[ProvinceId]].arbitrary
+    yield Neighbour(a, b))
+
+  given Arbitrary[NeighbourSpec] =
+    Arbitrary(for
+      a <- summon[Arbitrary[ProvinceId]].arbitrary
+      b <- summon[Arbitrary[ProvinceId]].arbitrary
+      f <- summon[Arbitrary[BorderFlag]].arbitrary
+    yield NeighbourSpec(a, b, f))
+
+  given Arbitrary[MapDirective] =
+    val gen = Gen.oneOf[
+      MapDirective](
+      summon[Arbitrary[Dom2Title]].arbitrary,
+      summon[Arbitrary[ImageFile]].arbitrary,
+      summon[Arbitrary[MapSize]].arbitrary,
+      summon[Arbitrary[DomVersion]].arbitrary,
+      Gen.const(HWrapAround),
+      Gen.const(NoDeepCaves),
+      Gen.const(NoDeepChoice),
+      Gen.const(MapNoHide),
+      summon[Arbitrary[MapTextColor]].arbitrary,
+      summon[Arbitrary[MapDomColor]].arbitrary,
+      summon[Arbitrary[AllowedPlayer]].arbitrary,
+      summon[Arbitrary[SpecStart]].arbitrary,
+      summon[Arbitrary[Terrain]].arbitrary,
+      summon[Arbitrary[LandName]].arbitrary,
+      summon[Arbitrary[Neighbour]].arbitrary,
+      summon[Arbitrary[NeighbourSpec]].arbitrary
+    )
+    Arbitrary(gen)

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
@@ -1,0 +1,32 @@
+package com.crib.bills.dom6maps
+
+import cats.effect.{IO, Sync}
+import cats.effect.unsafe.implicits.global
+import fs2.Stream
+import java.nio.charset.StandardCharsets
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+import model.*
+import model.map.*
+import Arbitraries.given
+import Renderer.*
+
+object MapRendererSpec extends Properties("MapRenderer"):
+  private def parseOne(line: String): Option[MapDirective] =
+    MapFileParser
+      .parse[IO]
+      .apply(Stream.emits((line + "\n").getBytes(StandardCharsets.UTF_8)).covary[IO])
+      .compile
+      .last
+      .unsafeRunSync()
+
+  property("render round trip") =
+    forAll { (directive: MapDirective) =>
+      parseOne(directive.render).contains(directive)
+    }
+
+  property("sample rendering") =
+    Dom2Title("foo").render == "#dom2title foo" &&
+    ImageFile("bar.tga").render == "#imagefile bar.tga" &&
+    MapSize(MapWidth(1), MapHeight(2)).render == "#mapsize 1 2" &&
+    LandName(ProvinceId(1), "name").render == "#landname 1 \"name\""

--- a/model/src/main/scala/model/map/Renderer.scala
+++ b/model/src/main/scala/model/map/Renderer.scala
@@ -1,0 +1,33 @@
+package com.crib.bills.dom6maps
+package model.map
+
+trait Renderer[T]:
+  def render(value: T): String
+
+object Renderer:
+  def apply[T](using r: Renderer[T]) = r
+
+  extension [T <: MapDirective](value: T)(using r: Renderer[MapDirective])
+    def render: String = r.render(value)
+
+  given Renderer[MapDirective] with
+    def render(directive: MapDirective): String =
+      directive match
+        case Dom2Title(value)      => s"#dom2title $value"
+        case ImageFile(value)      => s"#imagefile $value"
+        case MapSize(w, h)         => s"#mapsize ${w.value} ${h.value}"
+        case DomVersion(v)         => s"#domversion $v"
+        case HWrapAround           => "#hwraparound"
+        case NoDeepCaves           => "#nodeepcaves"
+        case NoDeepChoice          => "#nodeepchoice"
+        case MapNoHide             => "#mapnohide"
+        case MapTextColor(color)   =>
+          def f(c: ColorComponent) = c.value.toString
+          s"#maptextcol ${f(color.red)} ${f(color.green)} ${f(color.blue)} ${f(color.alpha)}"
+        case MapDomColor(r,g,b,a)  => s"#mapdomcol $r $g $b $a"
+        case AllowedPlayer(n)      => s"#allowedplayer ${n.id}"
+        case SpecStart(n,p)        => s"#specstart ${n.id} ${p.value}"
+        case Terrain(p,m)          => s"#terrain ${p.value} $m"
+        case LandName(p,n)         => s"#landname ${p.value} \"$n\""
+        case Neighbour(a,b)        => s"#neighbour ${a.value} ${b.value}"
+        case NeighbourSpec(a,b,f)  => s"#neighbourspec ${a.value} ${b.value} ${f.mask}"


### PR DESCRIPTION
## Summary
- add `Renderer` typeclass with basic instance for `MapDirective`
- provide generators for model types in `Arbitraries`
- test rendering round trips and sample output

## Testing Done
- `sbt compile`
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_b_6885658759f083278d6b84a03e92a738