### PR TITLE
Fix: use weaver in tests

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
@@ -1,46 +1,48 @@
 package com.crib.bills.dom6maps
 
-import cats.effect.{IO, Sync}
-import cats.effect.unsafe.implicits.global
+import cats.effect.IO
 import com.crib.bills.dom6maps.model.{BorderFlag, Nation, ProvinceId}
 import com.crib.bills.dom6maps.model.map.*
 import fs2.Stream
-import org.scalacheck.Properties
 import java.nio.charset.StandardCharsets
 import scala.io.Source
+import weaver.SimpleIOSuite
 
-object MapFileParserSpec extends Properties("MapFileParser") {
-  private val parsed =
+object MapFileParserSpec extends SimpleIOSuite:
+  private val parsedIO =
     MapFileParser
       .parse[IO]
       .apply(Stream.emits(Source.fromFile("data/test-map.map").mkString.getBytes(StandardCharsets.UTF_8)).covary[IO])
       .compile
       .toVector
-      .unsafeRunSync()
 
-  property("parses sample directives") =
-    parsed == Vector(
-      Dom2Title("Sample Map"),
-      ImageFile("sample.tga"),
-      MapSize(MapWidth(100), MapHeight(100)),
-      DomVersion(550),
-      HWrapAround,
-      NoDeepCaves,
-      MapNoHide,
-      MapTextColor(
-        FloatColor(
-          ColorComponent(0.10),
-          ColorComponent(0.20),
-          ColorComponent(0.30),
-          ColorComponent(1.00)
+  test("parses sample directives") {
+    parsedIO.map { parsed =>
+      expect(
+        parsed == Vector(
+          Dom2Title("Sample Map"),
+          ImageFile("sample.tga"),
+          MapSize(MapWidth(100), MapHeight(100)),
+          DomVersion(550),
+          HWrapAround,
+          NoDeepCaves,
+          MapNoHide,
+          MapTextColor(
+            FloatColor(
+              ColorComponent(0.10),
+              ColorComponent(0.20),
+              ColorComponent(0.30),
+              ColorComponent(1.00)
+            )
+          ),
+          MapDomColor(1, 2, 3, 4),
+          AllowedPlayer(Nation.Xibalba_Early),
+          SpecStart(Nation.Xibalba_Early, ProvinceId(1)),
+          Terrain(ProvinceId(1), 264),
+          LandName(ProvinceId(1), "Province One"),
+          Neighbour(ProvinceId(1), ProvinceId(2)),
+          NeighbourSpec(ProvinceId(1), ProvinceId(2), BorderFlag.MountainPass)
         )
-      ),
-      MapDomColor(1, 2, 3, 4),
-      AllowedPlayer(Nation.Xibalba_Early),
-      SpecStart(Nation.Xibalba_Early, ProvinceId(1)),
-      Terrain(ProvinceId(1), 264),
-      LandName(ProvinceId(1), "Province One"),
-      Neighbour(ProvinceId(1), ProvinceId(2)),
-      NeighbourSpec(ProvinceId(1), ProvinceId(2), BorderFlag.MountainPass)
-    )
-}
+      )
+    }
+  }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/HelloAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/HelloAppSpec.scala
@@ -1,8 +1,9 @@
 package com.crib.bills.dom6maps.apps
 
-import org.scalacheck.Properties
+import cats.effect.IO
+import weaver.SimpleIOSuite
 
-object HelloAppSpec extends Properties("HelloApp") {
-  property("greeting is hello") =
-    HelloApp.greeting == "hello"
-}
+object HelloAppSpec extends SimpleIOSuite:
+  test("greeting is hello") {
+    IO.pure(expect(HelloApp.greeting == "hello"))
+  }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorAppSpec.scala
@@ -1,7 +1,10 @@
 package com.crib.bills.dom6maps.apps
 
-import org.scalacheck.Properties
+import cats.effect.IO
+import weaver.SimpleIOSuite
 
-object MapEditorAppSpec extends Properties("MapEditorApp") {
-  property("app runs") = true
-}
+object MapEditorAppSpec extends SimpleIOSuite:
+  test("app runs") {
+    MapEditorApp.main(Array.empty)
+    IO.pure(expect(true))
+  }

--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,8 @@ Global / excludeLintKeys := Set(idePackagePrefix)
 
 lazy val commonSettings = Seq(
   idePackagePrefix := Some("com.crib.bills.dom6maps"),
-  testFrameworks += new TestFramework("org.scalacheck.ScalaCheckFramework")
+  testFrameworks += new TestFramework("org.scalacheck.ScalaCheckFramework"),
+  testFrameworks += new TestFramework("weaver.framework.CatsEffect")
 )
 
 lazy val model = (project in file("model"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   private val fs2Version        = "3.10.2"
   private val log4catsVersion   = "2.7.0"
   private val fastparseVersion  = "3.1.1"
+  private val weaverVersion     = "0.8.3"
 
   lazy val core = Seq(
     "org.typelevel" %% "cats-core"     % catsVersion,
@@ -16,7 +17,9 @@ object Dependencies {
   )
 
   lazy val tests = Seq(
-    "org.scalacheck" %% "scalacheck" % scalacheckVersion
+    "org.scalacheck" %% "scalacheck"     % scalacheckVersion,
+    "com.disneystreaming" %% "weaver-cats"      % weaverVersion,
+    "com.disneystreaming" %% "weaver-scalacheck" % weaverVersion
   )
 
   lazy val apps = Seq(


### PR DESCRIPTION
Updated tests to leverage weaver so that effectful code no longer uses unsafe execution.

### Testing Done
- `sbt compile`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68856a49836c8327b83b10e200718d38