### PR TITLE
Feature: scala-effect-mcp echo sample

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/McpEchoServer.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/McpEchoServer.scala
@@ -1,0 +1,49 @@
+package com.crib.bills.dom6maps
+package apps
+
+import cats.effect.{IO, IOApp, Resource}
+import cats.effect.ExitCode
+import cats.implicits.*
+import ch.linkyard.mcp.jsonrpc2.transport.StdioJsonRpcConnection
+import ch.linkyard.mcp.protocol.Initialize.PartyInfo
+import ch.linkyard.mcp.server.*
+import ch.linkyard.mcp.server.ToolFunction.Effect
+import com.melvinlow.json.schema.generic.auto.given
+import io.circe.generic.auto.given
+
+/**
+ * Minimal MCP server showcasing scala-effect-mcp integration.
+ * Provides a single "echo" tool that returns the supplied text.
+ */
+object McpEchoServer extends IOApp:
+  case class EchoInput(text: String)
+
+  private def echoTool: ToolFunction[IO] = ToolFunction.text(
+    ToolFunction.Info(
+      "echo",
+      Some("Echo"),
+      Some("Repeats the input text back to you"),
+      Effect.ReadOnly,
+      isOpenWorld = false
+    ),
+    (input: EchoInput, _) => IO.pure(input.text)
+  )
+
+  private class Session extends McpServer.Session[IO] with McpServer.ToolProvider[IO]:
+    override val serverInfo: PartyInfo = PartyInfo(
+      "DOM6 Maps Echo MCP",
+      "0.1.0"
+    )
+    override def instructions: IO[Option[String]] = IO.pure(None)
+    override val tools: IO[List[ToolFunction[IO]]] = IO.pure(List(echoTool))
+
+  private class Server extends McpServer[IO]:
+    override def initialize(client: McpServer.Client[IO]): Resource[IO, McpServer.Session[IO]] =
+      Resource.pure(Session())
+
+  override def run(args: List[String]): IO[ExitCode] =
+    Server().start(
+      StdioJsonRpcConnection.resource[IO],
+      e => IO.println(s"Error: $e")
+    ).useForever.as(ExitCode.Success)
+

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys.*
 
 val idePackagePrefix = settingKey[Option[String]]("IDE package prefix")
 
-ThisBuild / scalaVersion := "3.4.2"
+ThisBuild / scalaVersion := "3.7.1"
 ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / organization := "com.crib.bills"
 ThisBuild / organizationName := "Bill's Crib"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,6 +7,7 @@ object Dependencies {
   private val log4catsVersion   = "2.7.0"
   private val fastparseVersion  = "3.1.1"
   private val weaverVersion     = "0.8.3"
+  private val mcpVersion        = "0.2.0"
 
   lazy val core = Seq(
     "org.typelevel" %% "cats-core"     % catsVersion,
@@ -25,5 +26,7 @@ object Dependencies {
   lazy val apps = Seq(
     "org.typelevel" %% "log4cats-slf4j" % log4catsVersion,
     "com.lihaoyi" %% "fastparse"          % "3.1.0",
+    "ch.linkyard.mcp" %% "mcp-server"     % mcpVersion,
+    "ch.linkyard.mcp" %% "jsonrpc2-stdio" % mcpVersion,
   )
 }


### PR DESCRIPTION
## Summary
- add scala-effect-mcp dependencies
- bump Scala to 3.7.1
- implement `McpEchoServer` showcasing a simple echo tool

## Testing
- `sbt compile`

------
https://chatgpt.com/codex/tasks/task_b_688578b60bb0832791f89a62dfeb44cd