### PR TITLE
Feature: MCP Map Upload Server

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/McpMapServer.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/McpMapServer.scala
@@ -1,0 +1,86 @@
+package com.crib.bills.dom6maps
+package apps
+
+import cats.effect.{IO, IOApp, Resource}
+import cats.effect.ExitCode
+import cats.implicits.*
+import ch.linkyard.mcp.jsonrpc2.transport.StdioJsonRpcConnection
+import ch.linkyard.mcp.server.*
+import ch.linkyard.mcp.server.ToolFunction.Effect
+import fs2.Stream
+import java.nio.charset.StandardCharsets
+import io.circe.{Codec, Decoder, Encoder}
+import io.circe.generic.semiauto.*
+import io.circe.generic.auto.given
+import com.melvinlow.json.schema.generic.auto.given
+import io.circe.syntax.*
+
+import model.map.*
+import model.map.Renderer.*
+
+/**
+ * MCP server that accepts map uploads, applies configuration, and
+ * streams the resulting map back to the client.
+ */
+object McpMapServer extends IOApp:
+
+  final case class MapUploadConfig(mapSize: MapSize)
+  object MapUploadConfig:
+    given Codec[MapWidth] =
+      Codec.from(Decoder[Int].map(MapWidth.apply), Encoder[Int].contramap(_.value))
+    given Codec[MapHeight] =
+      Codec.from(Decoder[Int].map(MapHeight.apply), Encoder[Int].contramap(_.value))
+    given Codec[MapSize] =
+      Codec.forProduct2("x", "y")(MapSize.apply)(ms => (ms.width, ms.height))
+    given Codec[MapUploadConfig] =
+      Codec.forProduct1("map-size")(MapUploadConfig.apply)(_.mapSize)
+    given com.melvinlow.json.schema.JsonSchemaEncoder[MapUploadConfig] =
+      new com.melvinlow.json.schema.JsonSchemaEncoder[MapUploadConfig]:
+        def schema: io.circe.Json = io.circe.Json.obj()
+
+  import MapUploadConfig.given
+
+  final case class UploadRequest(config: MapUploadConfig, map: String)
+
+  private def processMap(request: UploadRequest): IO[String] =
+    val mapBytes = request.map.getBytes(StandardCharsets.UTF_8)
+    MapFileParser
+      .parse[IO]
+      .apply(Stream.emits(mapBytes).covary[IO])
+      .compile
+      .toVector
+      .map { directives =>
+        val rest = directives.filterNot(_.isInstanceOf[MapSize])
+        val newDirectives = MapSize(request.config.mapSize.width, request.config.mapSize.height) +: rest
+        newDirectives.map(_.render).mkString("\n")
+      }
+
+  private def uploadTool: ToolFunction[IO] = ToolFunction.text(
+    ToolFunction.Info(
+      "upload-map",
+      Some("Upload Map"),
+      Some("Uploads a map file and applies configuration"),
+      Effect.Destructive(false),
+      isOpenWorld = false
+    ),
+    (input: UploadRequest, _) => processMap(input)
+  )
+
+  private class Session extends McpServer.Session[IO] with McpServer.ToolProvider[IO]:
+    override val serverInfo: ch.linkyard.mcp.protocol.Initialize.PartyInfo = ch.linkyard.mcp.protocol.Initialize.PartyInfo(
+      "DOM6 Maps MCP",
+      "0.1.0"
+    )
+    override def instructions: IO[Option[String]] = IO.pure(None)
+    override val tools: IO[List[ToolFunction[IO]]] = IO.pure(List(uploadTool))
+
+  private class Server extends McpServer[IO]:
+    override def initialize(client: McpServer.Client[IO]): Resource[IO, McpServer.Session[IO]] =
+      Resource.pure(Session())
+
+  override def run(args: List[String]): IO[ExitCode] =
+    Server().start(
+      StdioJsonRpcConnection.resource[IO],
+      e => IO.println(s"Error: $e")
+    ).useForever.as(ExitCode.Success)
+

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapUploadConfigSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapUploadConfigSpec.scala
@@ -1,0 +1,16 @@
+package com.crib.bills.dom6maps
+
+import cats.effect.IO
+import weaver.SimpleIOSuite
+import io.circe.syntax.*
+import io.circe.parser.decode
+import apps.McpMapServer.MapUploadConfig
+import apps.McpMapServer.MapUploadConfig.given
+import model.map.{MapHeight, MapSize, MapWidth}
+
+object MapUploadConfigSpec extends SimpleIOSuite:
+  test("codec round trip") {
+    val cfg = MapUploadConfig(MapSize(MapWidth(10), MapHeight(20)))
+    val json = cfg.asJson
+    IO.pure(expect(decode[MapUploadConfig](json.noSpaces) == Right(cfg)))
+  }

--- a/documentation/engineering/architecture/README.md
+++ b/documentation/engineering/architecture/README.md
@@ -17,3 +17,4 @@ Item 2, the effect patterns are mandatory reading if you plan on writing code. I
 8. [Development Workflow](development_workflow.md) – [Full Context](../README_Architecture_And_Development_Guide.md#8-development-workflow)
 9. [Tech Stack](tech_stack.md) – [Full Context](../README_Architecture_And_Development_Guide.md#9-tech-stack)
 10. [Project Structure](project_structure.md)
+11. [MCP Map Server](../mcp_server.md)

--- a/documentation/engineering/architecture/project_structure.md
+++ b/documentation/engineering/architecture/project_structure.md
@@ -3,6 +3,7 @@
 This repository is organized as a multi-module sbt build.
 
 - `model` – data types for Dominions 6 map editing.
-- `apps` – command line utilities built on the model.
+- `apps` – command line utilities built on the model. Includes `McpMapServer`
+  for uploading maps over MCP.
 
 Refer to the root [AGENTS.md](../../AGENTS.md) for contribution guidelines and architectural references.

--- a/documentation/engineering/mcp_server.md
+++ b/documentation/engineering/mcp_server.md
@@ -1,0 +1,7 @@
+# MCP Map Server
+
+The MCP map server exposes a minimal Map Control Protocol (MCP) endpoint. It accepts map files uploaded over JSON‑RPC, applies a request specific configuration, and returns the processed map text.
+
+Currently the only supported configuration option is `map-size`. The field contains an `x` and `y` dimension that replace any existing `#mapsize` directive in the uploaded map.
+
+The implementation lives in `apps/src/main/scala/com/crib/bills/dom6maps/apps/McpMapServer.scala` and demonstrates basic integration with the `mcp-server` library.


### PR DESCRIPTION
## Summary
- add a simple MCP server capable of uploading and processing maps
- document the MCP map server and update architecture index
- document the new apps module entry in the project structure
- test `MapUploadConfig` circe codec

## Testing Done
- `sbt compile`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68858f5edb68832795ebafabbbde36b6