### PR TITLE
Feature: Map upload service

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/map/Impl.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/map/Impl.scala
@@ -1,0 +1,24 @@
+package com.crib.bills.dom6maps
+package apps.services.map
+
+import cats.effect.Async
+import cats.syntax.all.*
+import fs2.Stream
+import java.nio.charset.StandardCharsets
+import model.map.*
+import model.map.Renderer.*
+
+trait Impl[Sequencer[_]] extends Service[Sequencer]:
+  protected given sequencer: Async[Sequencer]
+
+  override def processUpload(request: MapUploadRequest): Sequencer[String] =
+    for
+      bytes <- sequencer.delay(request.map.getBytes(StandardCharsets.UTF_8))
+      directives <- MapFileParser
+                      .parse[Sequencer]
+                      .apply(Stream.emits(bytes).covary[Sequencer])
+                      .compile
+                      .toVector
+      rest = directives.filterNot(_.isInstanceOf[MapSize])
+      newDirectives = MapSize(request.config.mapSize.width, request.config.mapSize.height) +: rest
+    yield newDirectives.map(_.render).mkString("\n")

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/map/Service.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/map/Service.scala
@@ -1,0 +1,9 @@
+package com.crib.bills.dom6maps
+package apps.services.map
+
+import model.map.MapUploadRequest
+
+trait Service[Sequencer[_]]:
+  protected def mapUploadService: Service[Sequencer] = this
+
+  def processUpload(request: MapUploadRequest): Sequencer[String]

--- a/model/src/main/scala/model/map/Upload.scala
+++ b/model/src/main/scala/model/map/Upload.scala
@@ -1,0 +1,5 @@
+package com.crib.bills.dom6maps
+package model.map
+
+final case class MapUploadConfig(mapSize: MapSize)
+final case class MapUploadRequest(config: MapUploadConfig, map: String)


### PR DESCRIPTION
## Summary
- create `MapUploadConfig` and `MapUploadRequest` models
- add new `map` upload service trait and implementation
- refactor `McpMapServer` to use the service

## Testing
- `sbt "project apps" "compile"`
- `sbt "compile"`


------
https://chatgpt.com/codex/tasks/task_b_6885a27f7e848327a3e05e7eed2c6e8c