### PR TITLE
Feature: Wrap sever app

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/WrapSeverApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/WrapSeverApp.scala
@@ -1,0 +1,37 @@
+package com.crib.bills.dom6maps
+package apps
+
+import cats.effect.{IO, IOApp}
+import fs2.io.file.{Files, Path}
+import com.crib.bills.dom6maps.model.ProvinceId
+import com.crib.bills.dom6maps.model.map.{MapDirective, MapFileParser, Neighbour, NeighbourSpec, HWrapAround, MapWidth, MapHeight}
+import com.crib.bills.dom6maps.model.map.Renderer.*
+
+object WrapSeverApp extends IOApp.Simple:
+  private val inputFile = Path("data") / "five-by-twelve.map"
+  private val mapWidth = MapWidth(5)
+  private val mapHeight = MapHeight(12)
+
+  def process(directives: Vector[MapDirective]): Vector[MapDirective] =
+    val withoutConnections = directives.filter {
+      case Neighbour(a, b)      => !isTopBottom(a, b)
+      case NeighbourSpec(a, b, _) => !isTopBottom(a, b)
+      case _                    => true
+    }
+    val withoutWrapDirective = withoutConnections.filterNot(_ == HWrapAround)
+    withoutWrapDirective :+ HWrapAround
+
+  private def isTopBottom(a: ProvinceId, b: ProvinceId): Boolean =
+    val rowA = (a.value - 1) / mapWidth.value
+    val rowB = (b.value - 1) / mapWidth.value
+    val top = 0
+    val bottom = mapHeight.value - 1
+    (rowA == top && rowB == bottom) || (rowA == bottom && rowB == top)
+
+  def run: IO[Unit] =
+    MapFileParser
+      .parseFile[IO](inputFile)
+      .compile
+      .toVector
+      .map(process)
+      .flatMap(ds => IO.println(ds.map(_.render).mkString("\n")))

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapUploadConfigSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapUploadConfigSpec.scala
@@ -4,8 +4,8 @@ import cats.effect.IO
 import weaver.SimpleIOSuite
 import io.circe.syntax.*
 import io.circe.parser.decode
-import apps.McpMapServer.MapUploadConfig
-import apps.McpMapServer.MapUploadConfig.given
+import model.map.MapUploadConfig
+import apps.McpMapServer.given
 import model.map.{MapHeight, MapSize, MapWidth}
 
 object MapUploadConfigSpec extends SimpleIOSuite:

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/WrapSeverAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/WrapSeverAppSpec.scala
@@ -1,0 +1,39 @@
+package com.crib.bills.dom6maps
+package apps
+
+import cats.effect.IO
+import fs2.io.file.{Files, Path}
+import com.crib.bills.dom6maps.model.ProvinceId
+import com.crib.bills.dom6maps.model.map.{HWrapAround, MapFileParser, Neighbour}
+import weaver.SimpleIOSuite
+
+object WrapSeverAppSpec extends SimpleIOSuite:
+  private val mapWidth = 5
+  private val mapHeight = 12
+
+  private def isTopBottom(a: ProvinceId, b: ProvinceId): Boolean =
+    val rowA = (a.value - 1) / mapWidth
+    val rowB = (b.value - 1) / mapWidth
+    val top = 0
+    val bottom = mapHeight - 1
+    (rowA == top && rowB == bottom) || (rowA == bottom && rowB == top)
+
+  test("adds hwrap and removes top-bottom neighbours") {
+    MapFileParser
+      .parseFile[IO](Path("data/five-by-twelve.map"))
+      .compile
+      .toVector
+      .map(WrapSeverApp.process)
+      .map { directives =>
+        val hasHWrap = directives.contains(HWrapAround)
+        val hasTopBottom = directives.exists {
+          case Neighbour(a, b) => isTopBottom(a, b)
+          case _               => false
+        }
+        val hasMiddle = directives.exists {
+          case Neighbour(a, b) => a.value == 6 && b.value == 7
+          case _               => false
+        }
+        expect(hasHWrap && !hasTopBottom && hasMiddle)
+      }
+  }

--- a/data/five-by-twelve.map
+++ b/data/five-by-twelve.map
@@ -1,0 +1,11 @@
+-- Example 5x12 map
+#dom2title Sample 5x12 Map
+#imagefile sample_5x12.tga
+#mapsize 5 12
+#domversion 550
+#neighbour 1 56
+#neighbour 2 57
+#neighbour 3 58
+#neighbour 4 59
+#neighbour 5 60
+#neighbour 6 7


### PR DESCRIPTION
## Summary
- add app to convert maps to horizontal wrapping and sever top-bottom connections
- cover map upload codec import in tests

## Testing Done
- `sbt "project apps" test`


------
https://chatgpt.com/codex/tasks/task_b_688e7bd3b87c8327b6a5fc032771b1ba