### PR TITLE
Fix: handle terrain mask overflow

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/WrapSeverApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/WrapSeverApp.scala
@@ -2,6 +2,7 @@ package com.crib.bills.dom6maps
 package apps
 
 import cats.effect.{IO, IOApp}
+import fs2.{Stream}
 import fs2.io.file.{Files, Path}
 import com.crib.bills.dom6maps.model.ProvinceId
 import com.crib.bills.dom6maps.model.map.{MapDirective, MapFileParser, Neighbour, NeighbourSpec, HWrapAround, MapWidth, MapHeight}
@@ -17,9 +18,9 @@ object WrapSeverApp extends IOApp.Simple:
       .compile
       .toVector
       .map(WrapSever.process)
-      .flatMap { ds =>
+      .flatMap { directives =>
         Stream
-          .emit(ds.map(_.render).mkString("\n"))
+          .emit(directives.map(_.render).mkString("\n"))
           .through(fs2.text.utf8.encode)
           .through(Files[IO].writeAll(outputFile))
           .compile

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
@@ -16,6 +16,13 @@ object MapFileParserSpec extends SimpleIOSuite:
       .compile
       .toVector
 
+  private val largeMaskParsedIO =
+    MapFileParser
+      .parse[IO]
+      .apply(Stream.emits("#terrain 1 2147483712\n".getBytes(StandardCharsets.UTF_8)).covary[IO])
+      .compile
+      .toVector
+
   test("parses sample directives") {
     parsedIO.map { parsed =>
       expect(
@@ -44,5 +51,11 @@ object MapFileParserSpec extends SimpleIOSuite:
           NeighbourSpec(ProvinceId(1), ProvinceId(2), BorderFlag.MountainPass)
         )
       )
+    }
+  }
+
+  test("parses terrain mask above Int.MaxValue") {
+    largeMaskParsedIO.map { parsed =>
+      expect(parsed == Vector(Terrain(ProvinceId(1), -2147483584)))
     }
   }

--- a/model/src/main/scala/model/map/MapFileParser.scala
+++ b/model/src/main/scala/model/map/MapFileParser.scala
@@ -22,7 +22,8 @@ object MapFileParser:
       .collect { case Some(directive) => directive }
 
   private def ws[$: P]: P[Unit] = P(CharIn(" \t").rep(1))
-  private def int[$: P]: P[Int] = P(CharIn("0-9").rep(1).!.map(_.toInt))
+  private def int[$: P]: P[Int] =
+    P(CharIn("0-9").rep(1).!.map(_.toLong.toInt))
   private def dbl[$: P]: P[Double] = P(CharIn("0-9.").rep(1).!.map(_.toDouble))
   private def rest[$: P]: P[String] = P(CharsWhile(_ != '\n').!.map(_.trim))
   private def quoted[$: P]: P[String] = P("\"" ~/ CharsWhile(_ != '"').! ~ "\"")


### PR DESCRIPTION
## Summary
- parse numeric tokens as `Long` before casting to `Int` to preserve bit patterns above `Int.MaxValue`
- exercise terrain parsing with a mask exceeding `Int.MaxValue`
- import fs2 `Stream` and rename variables in `WrapSeverApp` to restore compilation

## Testing
- `sbt compile`
- `sbt "project apps" test`


------
https://chatgpt.com/codex/tasks/task_b_688e837da24083279da62b729ae7a06b