### PR TITLE
Feature: Map editor pipeline tests

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapEditorCopierSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapEditorCopierSpec.scala
@@ -1,0 +1,33 @@
+package com.crib.bills.dom6maps
+package apps.services.mapeditor
+
+import cats.effect.IO
+import cats.instances.either.*
+import cats.syntax.all.*
+import fs2.io.file.{Files => Fs2Files, Path}
+import weaver.SimpleIOSuite
+import java.nio.file.Files
+import java.nio.charset.StandardCharsets
+
+object MapEditorCopierSpec extends SimpleIOSuite:
+  type EC[A] = Either[Throwable, A]
+
+  test("copies assets while extracting map file") {
+    val copier = new MapEditorCopierImpl[IO]
+    for
+      sourceDir <- IO(Files.createTempDirectory("source-editor"))
+      destDir <- IO(Files.createTempDirectory("dest-editor"))
+      _ <- IO(Files.write(sourceDir.resolve("map.map"), "#dom2title Test".getBytes(StandardCharsets.UTF_8)))
+      _ <- IO(Files.write(sourceDir.resolve("image.tga"), Array[Byte](1, 2, 3)))
+      result <- copier.copyWithoutMap[EC](Path.fromNioPath(sourceDir), Path.fromNioPath(destDir))
+      tuple <- IO.fromEither(result)
+      (stream, outPath) = tuple
+      bytes <- stream.compile.toVector
+      destEntries <- Fs2Files[IO].list(Path.fromNioPath(destDir)).compile.toList
+    yield expect.all(
+      bytes == "#dom2title Test".getBytes(StandardCharsets.UTF_8).toVector,
+      destEntries.exists(_.fileName.toString == "image.tga"),
+      !destEntries.exists(_.fileName.toString == "map.map"),
+      outPath.fileName.toString == "map.map"
+    )
+  }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapProcessingServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapProcessingServiceSpec.scala
@@ -1,0 +1,46 @@
+package com.crib.bills.dom6maps
+package apps.services.mapeditor
+
+import cats.effect.IO
+import cats.instances.either.*
+import cats.syntax.all.*
+import fs2.Pipe
+import fs2.io.file.Path
+import weaver.SimpleIOSuite
+import java.nio.file.Files
+import java.nio.file.attribute.FileTime
+import java.nio.charset.StandardCharsets
+import model.map.{MapDirective, MapNoHide, MapFileParser}
+
+object MapProcessingServiceSpec extends SimpleIOSuite:
+  type EC[A] = Either[Throwable, A]
+
+  test("process selects latest editor and writes transformed map") {
+    val finder = new LatestEditorFinderImpl[IO]
+    val copier = new MapEditorCopierImpl[IO]
+    val transformer = new MapDirectiveTransformerImpl[IO]
+    val writer = new MapWriterImpl[IO]
+    val service = new MapProcessingServiceImpl[IO](finder, copier, transformer, writer)
+    val pipe: Pipe[IO, MapDirective, MapDirective] = _.filter {
+      case MapNoHide => false
+      case d         => true
+    }
+    for
+      rootDir <- IO(Files.createTempDirectory("root-editor"))
+      older <- IO(Files.createDirectory(rootDir.resolve("older")))
+      newer <- IO(Files.createDirectory(rootDir.resolve("newer")))
+      _ <- IO(Files.write(older.resolve("old.map"), "#dom2title Old".getBytes(StandardCharsets.UTF_8)))
+      _ <- IO(Files.setLastModifiedTime(older, FileTime.fromMillis(1000)))
+      _ <- IO(Files.copy(Path("data/test-map.map").toNioPath, newer.resolve("map.map")))
+      _ <- IO(Files.write(newer.resolve("image.tga"), Array[Byte](1,2,3)))
+      _ <- IO(Files.setLastModifiedTime(newer, FileTime.fromMillis(2000)))
+      destDir <- IO(Files.createTempDirectory("dest-editor"))
+      resultEC <- service.process[EC](Path.fromNioPath(rootDir), Path.fromNioPath(destDir), pipe)
+      outPath <- IO.fromEither(resultEC)
+      directives <- MapFileParser.parseFile[IO](outPath).compile.toVector
+    yield expect.all(
+      outPath.fileName.toString == "map.map",
+      directives.nonEmpty,
+      !directives.contains(MapNoHide)
+    )
+  }


### PR DESCRIPTION
## Summary
- verify MapEditorCopier copies non-map assets and returns the map bytes
- add end-to-end MapProcessingService test covering directory selection, transformation, and map writing

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_6890fd74656083278989cc32a2eb70de