### PR TITLE
Feature: Map editor wrap app

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorWrapApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorWrapApp.scala
@@ -1,0 +1,41 @@
+package com.crib.bills.dom6maps
+package apps
+
+import cats.effect.{ExitCode, IO, IOApp}
+import cats.instances.either.*
+import cats.syntax.all.*
+import fs2.io.file.Path
+import services.mapeditor.{MapEditorCopierImpl, MapWriterImpl}
+import model.map.{MapFileParser, MapSize}
+
+object MapEditorWrapApp extends IOApp:
+  type EC[A] = Either[Throwable, A]
+
+  override def run(args: List[String]): IO[ExitCode] =
+    args match
+      case source :: dest :: Nil =>
+        val src = Path(source)
+        val dst = Path(dest)
+        val copier = new MapEditorCopierImpl[IO]
+        val writer = new MapWriterImpl[IO]
+        val process: IO[EC[Unit]] =
+          copier.copyWithoutMap[EC](src, dst).flatMap {
+            case Left(err) => IO.pure(Left(err))
+            case Right((bytes, outPath)) =>
+              bytes.through(MapFileParser.parse[IO]).compile.toVector.flatMap { directives =>
+                directives.collectFirst { case MapSize(w, h) => (w, h) } match
+                  case Some((w, h)) =>
+                    val severed = WrapSever.severVertically(directives, w, h)
+                    val fileName = outPath.fileName.toString.stripSuffix(".map") + ".hwrap.map"
+                    val target = dst / fileName
+                    writer.write[EC](severed, target)
+                  case None =>
+                    IO.pure(Left(new NoSuchElementException("#mapsize not found")))
+              }
+          }
+        process.flatMap {
+          case Left(err) => IO.raiseError(err)
+          case Right(_)  => IO.pure(ExitCode.Success)
+        }
+      case _ =>
+        IO.println("Usage: MapEditorWrapApp <input-dir> <output-dir>").as(ExitCode(2))

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
@@ -1,0 +1,42 @@
+package com.crib.bills.dom6maps
+package apps
+
+import cats.effect.IO
+import fs2.io.file.{Files => Fs2Files, Path}
+import com.crib.bills.dom6maps.model.map.{
+  HWrapAround,
+  MapFileParser,
+  MapSize,
+  Neighbour,
+  NeighbourSpec
+}
+import WrapSever.isTopBottom
+import weaver.SimpleIOSuite
+import java.nio.file.Files
+
+object MapEditorWrapAppSpec extends SimpleIOSuite:
+  test("copies editor and severs map to hwrap") {
+    for
+      srcDir <- IO(Files.createTempDirectory("source-editor"))
+      _ <- IO(Files.copy(Path("data/five-by-twelve.map").toNioPath, srcDir.resolve("map.map")))
+      _ <- IO(Files.write(srcDir.resolve("image.tga"), Array[Byte](1,2,3)))
+      destDir <- IO(Files.createTempDirectory("dest-editor"))
+      _ <- MapEditorWrapApp.run(List(srcDir.toString, destDir.toString))
+      destEntries <- Fs2Files[IO].list(Path.fromNioPath(destDir)).compile.toList
+      mapPath = Path.fromNioPath(destDir.resolve("map.hwrap.map"))
+      directives <- MapFileParser.parseFile[IO](mapPath).compile.toVector
+      size = directives.collectFirst { case MapSize(w, h) => (w, h) }.get
+      (w, h) = size
+      hasTopBottom = directives.exists {
+        case Neighbour(a, b)     => isTopBottom(a, b, w, h)
+        case NeighbourSpec(a,b,_)=> isTopBottom(a, b, w, h)
+        case _                   => false
+      }
+    yield expect.all(
+      destEntries.exists(_.fileName.toString == "image.tga"),
+      destEntries.exists(_.fileName.toString == "map.hwrap.map"),
+      !destEntries.exists(_.fileName.toString == "map.map"),
+      directives.contains(HWrapAround),
+      !hasTopBottom
+    )
+  }

--- a/documentation/engineering/architecture/map_editor_pipeline.md
+++ b/documentation/engineering/architecture/map_editor_pipeline.md
@@ -72,6 +72,8 @@ This document captures the initial plan for processing map-editor directories an
    - Implement rendering/writing logic and integration tests covering the full pipeline.
 5. **Documentation & examples**
    - Update architecture docs with links to new services and provide an example module demonstrating end-to-end usage.
+   - Example: [MapEditorWrapApp](../../../apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorWrapApp.scala) copies a
+     map-editor directory and severs the map to horizontal wrap.
 
 ## Service Contract Boundaries
 - Each service is a small, single-responsibility trait following the capability pattern and accepting abstract `Sequencer` and `ErrorChannel` type parameters.


### PR DESCRIPTION
## Summary
- add MapEditorWrapApp for copying a map-editor directory and severing to an hwrap map
- test MapEditorWrapApp to ensure assets copy and top/bottom links are removed
- document MapEditorWrapApp in map editor pipeline guide

## Testing
- `sbt test` *(fails: NullPointerException in Scala compiler)*


------
https://chatgpt.com/codex/tasks/task_b_689107215e088327a231e45d8b6644d3