### PR TITLE
Feature: MapEditorWrapApp reads paths from config

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorWrapApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorWrapApp.scala
@@ -7,36 +7,38 @@ import cats.syntax.all.*
 import fs2.io.file.Path
 import model.map.{MapFileParser, MapSize}
 import services.mapeditor.{LatestEditorFinderImpl, MapEditorCopierImpl, MapWriterImpl}
+import pureconfig.*
+import pureconfig.generic.derivation.default.*
+import java.nio.file.Path as NioPath
 
 object MapEditorWrapApp extends IOApp:
   private type ErrorOr[A] = Either[Throwable, A]
 
+  private final case class PathsConfig(source: NioPath, dest: NioPath) derives ConfigReader
+
+  private val configFileName = "map-editor-wrap.conf"
+
   override def run(args: List[String]): IO[ExitCode] =
-    args match
-      case srcStr :: destStr :: Nil =>
-        val finder = new LatestEditorFinderImpl[IO]
-        val copier = new MapEditorCopierImpl[IO]
-        val writer = new MapWriterImpl[IO]
-        val srcRoot = Path(srcStr)
-        val destRoot = Path(destStr)
-        val action =
-          for
-            latestEC <- finder.mostRecentFolder[ErrorOr](srcRoot)
-            latest <- IO.fromEither(latestEC)
-            targetDir = destRoot / latest.fileName.toString
-            res <- copier.copyWithoutMap[ErrorOr](latest, targetDir)
-            (bytes, outPath) <- IO.fromEither(res)
-            directives <- bytes.through(MapFileParser.parse[IO]).compile.toVector
-            (w, h) <- IO.fromOption(directives.collectFirst { case MapSize(w, h) => (w, h) })(
-              new NoSuchElementException("#mapsize not found")
-            )
-            severed = WrapSever.severVertically(directives, w, h)
-            fileName = outPath.fileName.toString.stripSuffix(".map") + ".hwrap.map"
-            finalPath = outPath.parent.getOrElse(targetDir) / fileName
-            written <- writer.write[ErrorOr](severed, finalPath)
-            _ <- IO.fromEither(written)
-          yield ExitCode.Success
-        action
-      case _ =>
-        IO.println("Usage: MapEditorWrapApp <input-dir> <output-dir>").as(ExitCode(2))
+    val finder = new LatestEditorFinderImpl[IO]
+    val copier = new MapEditorCopierImpl[IO]
+    val writer = new MapWriterImpl[IO]
+    val action =
+      for
+        cfg <- IO(ConfigSource.file(configFileName).loadOrThrow[PathsConfig])
+        srcRoot = Path.fromNioPath(cfg.source)
+        destRoot = Path.fromNioPath(cfg.dest)
+        latestEC <- finder.mostRecentFolder[ErrorOr](srcRoot)
+        latest <- IO.fromEither(latestEC)
+        targetDir = destRoot / latest.fileName.toString
+        res <- copier.copyWithoutMap[ErrorOr](latest, targetDir)
+        (bytes, outPath) <- IO.fromEither(res)
+        directives <- bytes.through(MapFileParser.parse[IO]).compile.toVector
+        (w, h) <- IO.fromOption(directives.collectFirst { case MapSize(w, h) => (w, h) })(
+          new NoSuchElementException("#mapsize not found")
+        )
+        severed = WrapSever.severVertically(directives, w, h)
+        written <- writer.write[ErrorOr](severed, outPath)
+        _ <- IO.fromEither(written)
+      yield ExitCode.Success
+    action
 

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
@@ -3,7 +3,7 @@ package apps
 
 import cats.effect.IO
 import cats.syntax.all.*
-import fs2.io.file.{Files => Fs2Files, Path}
+import fs2.io.file.{Files as Fs2Files, Path}
 import com.crib.bills.dom6maps.model.map.{
   HWrapAround,
   MapFileParser,
@@ -13,43 +13,47 @@ import com.crib.bills.dom6maps.model.map.{
 }
 import WrapSever.isTopBottom
 import weaver.SimpleIOSuite
-import java.nio.file.Files
+import java.nio.file.{Files as JFiles, Path as JPath}
 import java.nio.file.attribute.FileTime
 
 object MapEditorWrapAppSpec extends SimpleIOSuite:
   test("copies latest editor and severs map to hwrap") {
     for
-      rootDir <- IO(Files.createTempDirectory("root-editor"))
-      older <- IO(Files.createDirectory(rootDir.resolve("older")))
-      newer <- IO(Files.createDirectory(rootDir.resolve("newer")))
-      _ <- IO(Files.copy(Path("data/five-by-twelve.map").toNioPath, older.resolve("old.map")))
-      _ <- IO(Files.write(older.resolve("old.tga"), Array[Byte](1,2,3)))
-      _ <- IO(Files.setLastModifiedTime(older, FileTime.fromMillis(1000)))
-      _ <- IO(Files.copy(Path("data/five-by-twelve.map").toNioPath, newer.resolve("map.map")))
-      _ <- IO(Files.write(newer.resolve("image.tga"), Array[Byte](1,2,3)))
-      _ <- IO(Files.setLastModifiedTime(newer, FileTime.fromMillis(2000)))
-      destRoot <- IO(Files.createTempDirectory("dest-editor"))
-      _ <- MapEditorWrapApp.run(List(rootDir.toString, destRoot.toString))
+      rootDir <- IO(JFiles.createTempDirectory("root-editor"))
+      older <- IO(JFiles.createDirectory(rootDir.resolve("older")))
+      newer <- IO(JFiles.createDirectory(rootDir.resolve("newer")))
+      _ <- IO(JFiles.copy(Path("data/five-by-twelve.map").toNioPath, older.resolve("old.map")))
+      _ <- IO(JFiles.write(older.resolve("old.tga"), Array[Byte](1, 2, 3)))
+      _ <- IO(JFiles.setLastModifiedTime(older, FileTime.fromMillis(1000)))
+      _ <- IO(JFiles.copy(Path("data/five-by-twelve.map").toNioPath, newer.resolve("map.map")))
+      _ <- IO(JFiles.write(newer.resolve("image.tga"), Array[Byte](1, 2, 3)))
+      _ <- IO(JFiles.setLastModifiedTime(newer, FileTime.fromMillis(2000)))
+      destRoot <- IO(JFiles.createTempDirectory("dest-editor"))
+      configFile = JPath.of("map-editor-wrap.conf")
+      _ <- IO(JFiles.writeString(configFile, s"""source="${rootDir.toString}"
+dest="${destRoot.toString}"
+"""))
+      _ <- MapEditorWrapApp.run(Nil).guarantee(IO(JFiles.deleteIfExists(configFile)))
       destEntries <- Fs2Files[IO].list(Path.fromNioPath(destRoot)).compile.toList
       destDir = Path.fromNioPath(destRoot.resolve("newer"))
       copiedEntries <- Fs2Files[IO].list(destDir).compile.toList
-      mapPath = destDir / "map.hwrap.map"
+      mapPath = destDir / "map.map"
       directives <- MapFileParser.parseFile[IO](mapPath).compile.toVector
       size <- IO.fromOption(directives.collectFirst { case MapSize(w, h) => (w, h) })(
         new NoSuchElementException("#mapsize not found")
       )
       (w, h) = size
       hasTopBottom = directives.exists {
-        case Neighbour(a, b)     => isTopBottom(a, b, w, h)
-        case NeighbourSpec(a,b,_)=> isTopBottom(a, b, w, h)
-        case _                   => false
+        case Neighbour(a, b)       => isTopBottom(a, b, w, h)
+        case NeighbourSpec(a, b, _) => isTopBottom(a, b, w, h)
+        case _                     => false
       }
     yield expect.all(
       destEntries.exists(_.fileName.toString == "newer"),
       copiedEntries.exists(_.fileName.toString == "image.tga"),
-      copiedEntries.exists(_.fileName.toString == "map.hwrap.map"),
-      !copiedEntries.exists(_.fileName.toString == "map.map"),
+      copiedEntries.exists(_.fileName.toString == "map.map"),
+      !copiedEntries.exists(_.fileName.toString == "map.hwrap.map"),
       directives.contains(HWrapAround),
-      !hasTopBottom
+      !hasTopBottom,
     )
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Dependencies {
   private val fastparseVersion  = "3.1.1"
   private val weaverVersion     = "0.8.3"
   private val mcpVersion        = "0.2.0"
+  private val pureconfigVersion = "0.17.7"
 
   lazy val core = Seq(
     "org.typelevel" %% "cats-core"     % catsVersion,
@@ -28,5 +29,7 @@ object Dependencies {
     "com.lihaoyi" %% "fastparse"          % "3.1.0",
     "ch.linkyard.mcp" %% "mcp-server"     % mcpVersion,
     "ch.linkyard.mcp" %% "jsonrpc2-stdio" % mcpVersion,
+    "com.github.pureconfig" %% "pureconfig-core"           % pureconfigVersion,
+    "com.github.pureconfig" %% "pureconfig-generic-scala3" % pureconfigVersion,
   )
 }


### PR DESCRIPTION
## Summary
- load source and destination directories from `map-editor-wrap.conf`
- keep original map filename when writing severed maps
- test MapEditorWrapApp with config-driven paths

## Testing
- `sbt "project apps" "testOnly com.crib.bills.dom6maps.apps.MapEditorWrapAppSpec"`


------
https://chatgpt.com/codex/tasks/task_b_68965f7a631c8327b1f40a385511532d