### PR TITLE
Feature: enable sbt assembly for apps project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import Dependencies.*
 import sbt.Keys.*
+import sbtassembly.AssemblyPlugin.autoImport._
 
 val idePackagePrefix = settingKey[Option[String]]("IDE package prefix")
 
@@ -27,7 +28,10 @@ lazy val apps = (project in file("apps"))
   .settings(
     name := "apps",
     libraryDependencies ++= Dependencies.tests.map(_ % Test) ++ Dependencies.apps,
-    commonSettings
+    commonSettings,
+    assembly / mainClass := Some("com.crib.bills.dom6maps.apps.HelloApp"),
+    Compile / mainClass := Some("com.crib.bills.dom6maps.apps.HelloApp"),
+    assembly / assemblyJarName := "apps-assembly.jar"
   )
 
 lazy val root = (project in file("."))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")


### PR DESCRIPTION
## Summary
- add sbt-assembly plugin
- configure apps project to build an executable assembly JAR

## Testing
- `sbt compile`
- `sbt "project apps" assembly`


------
https://chatgpt.com/codex/tasks/task_b_68966080f2f083279ae56bd6faefa52b