### PR TITLE
Fix: MapEditorWrapApp assembly entry point

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,8 +29,8 @@ lazy val apps = (project in file("apps"))
     name := "apps",
     libraryDependencies ++= Dependencies.tests.map(_ % Test) ++ Dependencies.apps,
     commonSettings,
-    assembly / mainClass := Some("com.crib.bills.dom6maps.apps.HelloApp"),
-    Compile / mainClass := Some("com.crib.bills.dom6maps.apps.HelloApp"),
+    assembly / mainClass := Some("com.crib.bills.dom6maps.apps.MapEditorWrapApp"),
+    Compile / mainClass := Some("com.crib.bills.dom6maps.apps.MapEditorWrapApp"),
     assembly / assemblyJarName := "apps-assembly.jar"
   )
 


### PR DESCRIPTION
## Summary
- direct the apps assembly to launch `MapEditorWrapApp`

## Testing
- `sbt compile`
- `sbt test`
- `sbt "project apps" assembly`
- `java -jar apps/target/scala-3.7.1/apps-assembly.jar`


------
https://chatgpt.com/codex/tasks/task_b_68967edb3c7c83279df5a0562f36ee22