### PR TITLE
Feature: Handle #pb and #specstart directives

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
@@ -66,6 +66,14 @@ object Arbitraries:
       p <- summon[Arbitrary[ProvinceId]].arbitrary
     yield SpecStart(n, p))
 
+  given Arbitrary[ProvincePixels] =
+    Arbitrary(for
+      x <- Gen.choose(0, 5000)
+      y <- Gen.choose(0, 5000)
+      l <- Gen.choose(1, 5000)
+      p <- summon[Arbitrary[ProvinceId]].arbitrary
+    yield ProvincePixels(x, y, l, p))
+
   given Arbitrary[Terrain] =
     Arbitrary(for
       p <- summon[Arbitrary[ProvinceId]].arbitrary
@@ -109,6 +117,7 @@ object Arbitraries:
       summon[Arbitrary[MapDomColor]].arbitrary,
       summon[Arbitrary[AllowedPlayer]].arbitrary,
       summon[Arbitrary[SpecStart]].arbitrary,
+      summon[Arbitrary[ProvincePixels]].arbitrary,
       summon[Arbitrary[Terrain]].arbitrary,
       summon[Arbitrary[LandName]].arbitrary,
       summon[Arbitrary[Neighbour]].arbitrary,

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
@@ -43,6 +43,7 @@ object MapFileParserSpec extends SimpleIOSuite:
             )
           ),
           MapDomColor(1, 2, 3, 4),
+          ProvincePixels(1, 2, 3, ProvinceId(1)),
           AllowedPlayer(Nation.Xibalba_Early),
           SpecStart(Nation.Xibalba_Early, ProvinceId(1)),
           Terrain(ProvinceId(1), 264),

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
@@ -31,5 +31,6 @@ object MapRendererSpec extends SimpleIOSuite with Checkers:
     val e2 = expect(ImageFile("bar.tga").render == "#imagefile bar.tga")
     val e3 = expect(MapSize(MapWidth(1), MapHeight(2)).render == "#mapsize 1 2")
     val e4 = expect(LandName(ProvinceId(1), "name").render == "#landname 1 \"name\"")
-    IO.pure(e1 and e2 and e3 and e4)
+    val e5 = expect(ProvincePixels(1, 2, 3, ProvinceId(4)).render == "#pb 1 2 3 4")
+    IO.pure(e1 and e2 and e3 and e4 and e5)
   }

--- a/data/test-map.map
+++ b/data/test-map.map
@@ -8,6 +8,7 @@
 #mapnohide
 #maptextcol 0.10 0.20 0.30 1.00
 #mapdomcol 1 2 3 4
+#pb 1 2 3 1
 #allowedplayer 31
 #specstart 31 1
 #terrain 1 264

--- a/model/src/main/scala/model/map/MapDirective.scala
+++ b/model/src/main/scala/model/map/MapDirective.scala
@@ -25,6 +25,7 @@ final case class MapDomColor(red: Int, green: Int, blue: Int, alpha: Int) extend
 import com.crib.bills.dom6maps.model.{Nation, ProvinceId, BorderFlag}
 final case class AllowedPlayer(nation: Nation) extends MapDirective
 final case class SpecStart(nation: Nation, province: ProvinceId) extends MapDirective
+final case class ProvincePixels(x: Int, y: Int, length: Int, province: ProvinceId) extends MapDirective
 final case class Terrain(province: ProvinceId, mask: Int) extends MapDirective
 final case class LandName(province: ProvinceId, name: String) extends MapDirective
 final case class Neighbour(a: ProvinceId, b: ProvinceId) extends MapDirective

--- a/model/src/main/scala/model/map/MapFileParser.scala
+++ b/model/src/main/scala/model/map/MapFileParser.scala
@@ -93,6 +93,11 @@ object MapFileParser:
       Nation.values.find(_.id == n).map(SpecStart(_, ProvinceId(p)))
     }
 
+  private def provincePixelsP[$: P]: P[Option[MapDirective]] =
+    P("#pb" ~ ws ~ int ~ ws ~ int ~ ws ~ int ~ ws ~ int).map {
+      case (x, y, len, p) => Some(ProvincePixels(x, y, len, ProvinceId(p)))
+    }
+
   private def terrainP[$: P]: P[Option[MapDirective]] =
     P("#terrain" ~ ws ~ int ~ ws ~ int).map { case (p, m) =>
       Some(Terrain(ProvinceId(p), m))
@@ -132,6 +137,7 @@ object MapFileParser:
       mapdomcolP |
       allowedPlayerP |
       specStartP |
+      provincePixelsP |
       terrainP |
       landnameP |
       neighbourP |

--- a/model/src/main/scala/model/map/Renderer.scala
+++ b/model/src/main/scala/model/map/Renderer.scala
@@ -30,6 +30,7 @@ object Renderer:
         case MapDomColor(r,g,b,a)  => s"#mapdomcol $r $g $b $a"
         case AllowedPlayer(n)      => s"#allowedplayer ${n.id}"
         case SpecStart(n,p)        => s"#specstart ${n.id} ${p.value}"
+        case ProvincePixels(x,y,l,p) => s"#pb $x $y $l ${p.value}"
         case Terrain(p,m)          => s"#terrain ${p.value} $m"
         case LandName(p,n)         => s"#landname ${p.value} \"$n\""
         case Neighbour(a,b)        => s"#neighbour ${a.value} ${b.value}"


### PR DESCRIPTION
## Summary
- Add ProvincePixels model and parser to support #pb map directives
- Ensure parser and renderer cover #specstart directives as well
- Extend map sample and tests to exercise these directives

## Testing
- `sbt compile`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_689791b96ee483278e89d66fb055e6be