### PR TITLE
Feature: Map directive type discovery service

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/DirectiveTypesApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/DirectiveTypesApp.scala
@@ -1,0 +1,16 @@
+package com.crib.bills.dom6maps
+package apps
+
+import cats.effect.{IO, IOApp}
+import fs2.io.file.Path
+import apps.services.map.{DirectiveTypesService, DirectiveTypesServiceImpl}
+
+object DirectiveTypesApp extends IOApp.Simple:
+  private val service: DirectiveTypesService[IO] = new DirectiveTypesServiceImpl[IO]
+
+  private val mapPath = Path("data/duel-map-example.map")
+
+  override def run: IO[Unit] =
+    service.collect(mapPath).flatMap { directives =>
+      IO.println(directives.mkString("\n"))
+    }

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/map/DirectiveTypesService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/map/DirectiveTypesService.scala
@@ -1,0 +1,20 @@
+package com.crib.bills.dom6maps
+package apps.services.map
+
+import cats.effect.Async
+import fs2.io.file.{Files, Path}
+import fs2.text
+
+trait DirectiveTypesService[Sequencer[_]]:
+  def collect(path: Path): Sequencer[Set[String]]
+
+class DirectiveTypesServiceImpl[Sequencer[_]: Async: Files] extends DirectiveTypesService[Sequencer]:
+  override def collect(path: Path): Sequencer[Set[String]] =
+    Files[Sequencer]
+      .readAll(path)
+      .through(text.utf8.decode)
+      .through(text.lines)
+      .map(_.takeWhile(_ != ' '))
+      .filter(_.nonEmpty)
+      .compile
+      .fold(Set.empty[String])(_ + _)


### PR DESCRIPTION
## Summary
- add DirectiveTypesService to stream a map file and collect unique directive tokens
- create DirectiveTypesApp to run the service and print discovered directives

## Testing Done
- `sbt compile`
- `sbt "project apps" "runMain com.crib.bills.dom6maps.apps.DirectiveTypesApp"`


------
https://chatgpt.com/codex/tasks/task_b_68979314dd588327a9e38bca584508a1