### PR TITLE
Fix: Handle one-indexed provinces in wrap sever

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/WrapSever.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/WrapSever.scala
@@ -23,18 +23,20 @@ object WrapSever:
       width: MapWidth,
       height: MapHeight
   ): Boolean =
-    val rowA = (a.value - 1) / width.value
-    val rowB = (b.value - 1) / width.value
-    val top = height.value - 1
-    val bottom = 0
+    val rowA = ((a.value - 1) / width.value) + 1
+    val rowB = ((b.value - 1) / width.value) + 1
+    val top = height.value
+    val bottom = 1
     (rowA == top && rowB == bottom) || (rowA == bottom && rowB == top)
 
   def isLeftRight(a: ProvinceId, b: ProvinceId, width: MapWidth): Boolean =
-    val colA = (a.value - 1) % width.value
-    val colB = (b.value - 1) % width.value
-    val left = 0
-    val right = width.value - 1
-    (colA == left && colB == right) || (colA == right && colB == left)
+    val rowA = ((a.value - 1) / width.value) + 1
+    val rowB = ((b.value - 1) / width.value) + 1
+    val colA = ((a.value - 1) % width.value) + 1
+    val colB = ((b.value - 1) % width.value) + 1
+    val left = 1
+    val right = width.value
+    rowA == rowB && ((colA == left && colB == right) || (colA == right && colB == left))
 
   private val wrapDirectives =
     Set[MapDirective](WrapAround, HWrapAround, VWrapAround, NoWrapAround)

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/WrapSeverAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/WrapSeverAppSpec.scala
@@ -3,6 +3,7 @@ package apps
 
 import cats.effect.IO
 import fs2.io.file.{Files, Path}
+import com.crib.bills.dom6maps.model.{ProvinceId}
 import com.crib.bills.dom6maps.model.map.{
   HWrapAround,
   MapFileParser,
@@ -89,4 +90,21 @@ object WrapSeverAppSpec extends SimpleIOSuite:
         }
         expect(hasVWrap && !hasLeftRight && hasMiddle)
       }
+  }
+
+  test("isTopBottom treats province ids as 1-indexed") {
+    IO.pure(
+      expect(
+        !isTopBottom(
+          ProvinceId(6),
+          ProvinceId(1),
+          MapWidth(5),
+          MapHeight(12)
+        )
+      )
+    )
+  }
+
+  test("isLeftRight only matches provinces on the same row") {
+    IO.pure(expect(!isLeftRight(ProvinceId(5), ProvinceId(6), MapWidth(5))))
   }


### PR DESCRIPTION
## Summary
- ensure wrap sever treats province IDs as one-indexed when detecting top/bottom and left/right neighbours
- constrain horizontal severing to provinces on the same row
- add unit tests covering 1-indexed logic and row checks

## Testing
- `sbt "project apps" "testOnly com.crib.bills.dom6maps.apps.WrapSeverAppSpec"`


------
https://chatgpt.com/codex/tasks/task_b_6897afd61e188327aad81f1c6f8cb4ed