### PR TITLE
Fix: distinguish pixel and province map sizes

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/McpMapServer.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/McpMapServer.scala
@@ -22,12 +22,12 @@ import apps.services.map.{Impl as UploadServiceImpl}
  */
 object McpMapServer extends IOApp:
 
-  given Codec[MapWidth] =
-    Codec.from(Decoder[Int].map(MapWidth.apply), Encoder[Int].contramap(_.value))
-  given Codec[MapHeight] =
-    Codec.from(Decoder[Int].map(MapHeight.apply), Encoder[Int].contramap(_.value))
-  given Codec[MapSize] =
-    Codec.forProduct2("x", "y")(MapSize.apply)(ms => (ms.width, ms.height))
+  given Codec[MapWidthPixels] =
+    Codec.from(Decoder[Int].map(MapWidthPixels.apply), Encoder[Int].contramap(_.value))
+  given Codec[MapHeightPixels] =
+    Codec.from(Decoder[Int].map(MapHeightPixels.apply), Encoder[Int].contramap(_.value))
+  given Codec[MapSizePixels] =
+    Codec.forProduct2("x", "y")(MapSizePixels.apply)(ms => (ms.width, ms.height))
   given Codec[MapUploadConfig] =
     Codec.forProduct1("map-size")(MapUploadConfig.apply)(_.mapSize)
   given com.melvinlow.json.schema.JsonSchemaEncoder[MapUploadConfig] =

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/map/Impl.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/map/Impl.scala
@@ -19,6 +19,6 @@ trait Impl[Sequencer[_]] extends Service[Sequencer]:
                       .apply(Stream.emits(bytes).covary[Sequencer])
                       .compile
                       .toVector
-      rest = directives.filterNot(_.isInstanceOf[MapSize])
-      newDirectives = MapSize(request.config.mapSize.width, request.config.mapSize.height) +: rest
+      rest = directives.filterNot(_.isInstanceOf[MapSizePixels])
+      newDirectives = MapSizePixels(request.config.mapSize.width, request.config.mapSize.height) +: rest
     yield newDirectives.map(_.render).mkString("\n")

--- a/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
@@ -14,11 +14,11 @@ object Arbitraries:
   given Arbitrary[BorderFlag] =
     Arbitrary(Gen.oneOf(BorderFlag.values.toSeq))
 
-  given Arbitrary[MapWidth] =
-    Arbitrary(Gen.choose(10, 5000).map(MapWidth.apply))
+  given Arbitrary[MapWidthPixels] =
+    Arbitrary(Gen.choose(10, 5000).map(MapWidthPixels.apply))
 
-  given Arbitrary[MapHeight] =
-    Arbitrary(Gen.choose(10, 5000).map(MapHeight.apply))
+  given Arbitrary[MapHeightPixels] =
+    Arbitrary(Gen.choose(10, 5000).map(MapHeightPixels.apply))
 
   given Arbitrary[Dom2Title] =
     Arbitrary(Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString).map(Dom2Title.apply))
@@ -29,11 +29,11 @@ object Arbitraries:
   given Arbitrary[WinterImageFile] =
     Arbitrary(Gen.nonEmptyListOf(Gen.alphaChar).map(n => WinterImageFile(s"$n.tga")))
 
-  given Arbitrary[MapSize] =
+  given Arbitrary[MapSizePixels] =
     Arbitrary(for
-      w <- summon[Arbitrary[MapWidth]].arbitrary
-      h <- summon[Arbitrary[MapHeight]].arbitrary
-    yield MapSize(w, h))
+      w <- summon[Arbitrary[MapWidthPixels]].arbitrary
+      h <- summon[Arbitrary[MapHeightPixels]].arbitrary
+    yield MapSizePixels(w, h))
 
   given Arbitrary[DomVersion] =
     Arbitrary(Gen.choose(500, 600).map(DomVersion.apply))
@@ -121,7 +121,7 @@ object Arbitraries:
       summon[Arbitrary[Dom2Title]].arbitrary,
       summon[Arbitrary[ImageFile]].arbitrary,
       summon[Arbitrary[WinterImageFile]].arbitrary,
-      summon[Arbitrary[MapSize]].arbitrary,
+      summon[Arbitrary[MapSizePixels]].arbitrary,
       summon[Arbitrary[DomVersion]].arbitrary,
       summon[Arbitrary[Description]].arbitrary,
       Gen.const(WrapAround),

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
@@ -29,7 +29,7 @@ object MapFileParserSpec extends SimpleIOSuite:
         parsed == Vector(
           Dom2Title("Sample Map"),
           ImageFile("sample.tga"),
-          MapSize(MapWidth(100), MapHeight(100)),
+          MapSizePixels(MapWidthPixels(100), MapHeightPixels(100)),
           DomVersion(550),
           HWrapAround,
           NoDeepCaves,

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
@@ -30,7 +30,7 @@ object MapRendererSpec extends SimpleIOSuite with Checkers:
     val e1 = expect(Dom2Title("foo").render == "#dom2title foo")
     val e2 = expect(ImageFile("bar.tga").render == "#imagefile bar.tga")
     val e3 = expect(WinterImageFile("baz.tga").render == "#winterimagefile baz.tga")
-    val e4 = expect(MapSize(MapWidth(1), MapHeight(2)).render == "#mapsize 1 2")
+    val e4 = expect(MapSizePixels(MapWidthPixels(1), MapHeightPixels(2)).render == "#mapsize 1 2")
     val e5 = expect(Description("d").render == "#description \"d\"")
     val e6 = expect(LandName(ProvinceId(1), "name").render == "#landname 1 \"name\"")
     val e7 = expect(Gate(ProvinceId(1), ProvinceId(2)).render == "#gate 1 2")

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapUploadConfigSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapUploadConfigSpec.scala
@@ -6,11 +6,11 @@ import io.circe.syntax.*
 import io.circe.parser.decode
 import model.map.MapUploadConfig
 import apps.McpMapServer.given
-import model.map.{MapHeight, MapSize, MapWidth}
+import model.map.{MapHeightPixels, MapSizePixels, MapWidthPixels}
 
 object MapUploadConfigSpec extends SimpleIOSuite:
   test("codec round trip") {
-    val cfg = MapUploadConfig(MapSize(MapWidth(10), MapHeight(20)))
+    val cfg = MapUploadConfig(MapSizePixels(MapWidthPixels(10), MapHeightPixels(20)))
     val json = cfg.asJson
     IO.pure(expect(decode[MapUploadConfig](json.noSpaces) == Right(cfg)))
   }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
@@ -7,7 +7,7 @@ import fs2.io.file.{Files as Fs2Files, Path}
 import com.crib.bills.dom6maps.model.map.{
   HWrapAround,
   MapFileParser,
-  MapSize,
+  MapSizePixels,
   Neighbour,
   NeighbourSpec
 }
@@ -50,10 +50,12 @@ dest="${destRoot.toString}"
       copiedEntries <- Fs2Files[IO].list(destDir).compile.toList
       mapPath = destDir / "map.map"
       directives <- MapFileParser.parseFile[IO](mapPath).compile.toVector
-      size <- IO.fromOption(directives.collectFirst { case MapSize(w, h) => (w, h) })(
+      sizePixels <- IO.fromOption(directives.collectFirst { case m: MapSizePixels => m })(
         new NoSuchElementException("#mapsize not found")
       )
-      (w, h) = size
+      provinceSize = sizePixels.toProvinceSize
+      w = provinceSize.width
+      h = provinceSize.height
       hasTopBottom = directives.exists {
         case Neighbour(a, b)       => isTopBottom(a, b, w, h)
         case NeighbourSpec(a, b, _) => isTopBottom(a, b, w, h)

--- a/data/five-by-twelve-horizontal.map
+++ b/data/five-by-twelve-horizontal.map
@@ -1,7 +1,7 @@
 -- Example 5x12 horizontal wrap map
 #dom2title Sample 5x12 Map Horizontal
 #imagefile sample_5x12.tga
-#mapsize 5 12
+#mapsize 1280 1920
 #domversion 550
 #wraparound
 #neighbour 5 1

--- a/data/five-by-twelve.map
+++ b/data/five-by-twelve.map
@@ -1,7 +1,7 @@
 -- Example 5x12 map
 #dom2title Sample 5x12 Map
 #imagefile sample_5x12.tga
-#mapsize 5 12
+#mapsize 1280 1920
 #domversion 550
 #wraparound
 #neighbour 1 56

--- a/documentation/engineering/mcp_server.md
+++ b/documentation/engineering/mcp_server.md
@@ -2,6 +2,6 @@
 
 The MCP map server exposes a minimal Map Control Protocol (MCP) endpoint. It accepts map files uploaded over JSON‑RPC, applies a request specific configuration, and returns the processed map text.
 
-Currently the only supported configuration option is `map-size`. The field contains an `x` and `y` dimension that replace any existing `#mapsize` directive in the uploaded map.
+Currently the only supported configuration option is `map-size`. The field contains an `x` and `y` dimension in pixels that replace any existing `#mapsize` directive in the uploaded map.  Internally, operations that work with provinces derive their dimensions from these pixel values by dividing the width by 256 and the height by 160.
 
 The implementation lives in `apps/src/main/scala/com/crib/bills/dom6maps/apps/McpMapServer.scala` and demonstrates basic integration with the `mcp-server` library.

--- a/model/src/main/scala/model/map/MapDirective.scala
+++ b/model/src/main/scala/model/map/MapDirective.scala
@@ -6,10 +6,21 @@ sealed trait MapDirective
 final case class MapWidth(value: Int) extends AnyVal
 final case class MapHeight(value: Int) extends AnyVal
 
+final case class MapWidthPixels(value: Int) extends AnyVal
+final case class MapHeightPixels(value: Int) extends AnyVal
+
+final case class ProvinceSize(width: MapWidth, height: MapHeight)
+
+final case class MapSizePixels(width: MapWidthPixels, height: MapHeightPixels) extends MapDirective:
+  def toProvinceSize: ProvinceSize =
+    ProvinceSize(
+      MapWidth(width.value / 256),
+      MapHeight(height.value / 160)
+    )
+
 final case class Dom2Title(value: String) extends MapDirective
 final case class ImageFile(value: String) extends MapDirective
 final case class WinterImageFile(value: String) extends MapDirective
-final case class MapSize(width: MapWidth, height: MapHeight) extends MapDirective
 final case class DomVersion(value: Int) extends MapDirective
 final case class Description(value: String) extends MapDirective
 case object WrapAround extends MapDirective

--- a/model/src/main/scala/model/map/MapFileParser.scala
+++ b/model/src/main/scala/model/map/MapFileParser.scala
@@ -39,7 +39,7 @@ object MapFileParser:
 
   private def mapSizeP[$: P]: P[Option[MapDirective]] =
     P("#mapsize" ~ ws ~ int ~ ws ~ int).map { case (w, h) =>
-      Some(MapSize(MapWidth(w), MapHeight(h)))
+      Some(MapSizePixels(MapWidthPixels(w), MapHeightPixels(h)))
     }
 
   private def domVersionP[$: P]: P[Option[MapDirective]] =

--- a/model/src/main/scala/model/map/Renderer.scala
+++ b/model/src/main/scala/model/map/Renderer.scala
@@ -16,7 +16,7 @@ object Renderer:
         case Dom2Title(value)      => s"#dom2title $value"
         case ImageFile(value)      => s"#imagefile $value"
         case WinterImageFile(value) => s"#winterimagefile $value"
-        case MapSize(w, h)         => s"#mapsize ${w.value} ${h.value}"
+        case MapSizePixels(w, h)    => s"#mapsize ${w.value} ${h.value}"
         case DomVersion(v)         => s"#domversion $v"
         case Description(value)    => s"#description \"$value\""
         case WrapAround            => "#wraparound"

--- a/model/src/main/scala/model/map/Upload.scala
+++ b/model/src/main/scala/model/map/Upload.scala
@@ -1,5 +1,5 @@
 package com.crib.bills.dom6maps
 package model.map
 
-final case class MapUploadConfig(mapSize: MapSize)
+final case class MapUploadConfig(mapSize: MapSizePixels)
 final case class MapUploadRequest(config: MapUploadConfig, map: String)


### PR DESCRIPTION
## Summary
- model pixel map dimensions separately from province counts and convert before severing
- parse and render `#mapsize` using pixels and update server configuration and samples accordingly
- document pixel-based `map-size` handling and province conversion

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_b_6897c7c25a748327b503cea5038ff98b