### PR TITLE
Feature: Directory configuration services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ When reviewing documentation, agents are expected to reference linked pages when
   - `engineering/` – development and architecture guides.
   - `domain/` – business domain references.
   - `philosophy/` – culture and rationale documents.
+  - [Directory Configuration Service](documentation/engineering/directory_configuration_service.md) – user directory selection and persistence.
 
 ## Supplemental Guidelines
 - Follow and apply architectural and structural patterns established by the project.

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/config/DirectoryChooser.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/config/DirectoryChooser.scala
@@ -1,0 +1,41 @@
+package com.crib.bills.dom6maps
+package apps.services.config
+
+import cats.{MonadError, Traverse}
+import cats.effect.Sync
+import cats.syntax.all.*
+import java.nio.file.Path as NioPath
+import javax.swing.JFileChooser
+
+trait DirectoryChooser[Sequencer[_]]:
+  protected def directoryChooser: DirectoryChooser[Sequencer] = this
+
+  def chooseDirectory[ErrorChannel[_]](
+      title: String
+  )(using
+      errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+  ): Sequencer[ErrorChannel[NioPath]]
+
+class DirectoryChooserImpl[Sequencer[_]](using Sync[Sequencer])
+    extends DirectoryChooser[Sequencer]:
+
+  override def chooseDirectory[ErrorChannel[_]](
+      title: String
+  )(using
+      errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+  ): Sequencer[ErrorChannel[NioPath]] =
+    for
+      chooser <- Sync[Sequencer].delay(new JFileChooser())
+      _ <- Sync[Sequencer].delay(chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY))
+      _ <- Sync[Sequencer].delay(chooser.setDialogTitle(title))
+      result <- Sync[Sequencer].delay(chooser.showOpenDialog(null))
+      selected <-
+        if result == JFileChooser.APPROVE_OPTION then
+          Sync[Sequencer]
+            .delay(chooser.getSelectedFile.toPath)
+            .map(errorChannel.pure)
+        else
+          errorChannel
+            .raiseError[NioPath](RuntimeException("Directory selection cancelled"))
+            .pure[Sequencer]
+    yield selected

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/config/DirectoryConfigService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/config/DirectoryConfigService.scala
@@ -1,0 +1,46 @@
+package com.crib.bills.dom6maps
+package apps.services.config
+
+import cats.{MonadError, Traverse}
+import cats.effect.Async
+import cats.syntax.all.*
+import java.nio.file.{Files as JFiles, Path as NioPath}
+
+trait DirectoryConfigService[Sequencer[_]]:
+  protected def directoryConfigService: DirectoryConfigService[Sequencer] = this
+
+  def selectAndStore[ErrorChannel[_]]()(using
+      errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+  ): Sequencer[ErrorChannel[Unit]]
+
+class DirectoryConfigServiceImpl[Sequencer[_]: Async](
+    chooser: DirectoryChooser[Sequencer]
+) extends DirectoryConfigService[Sequencer]:
+  private val configFileName = "map-editor-wrap.conf"
+
+  override def selectAndStore[ErrorChannel[_]]()(using
+      errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+  ): Sequencer[ErrorChannel[Unit]] =
+    for
+      sourceEC <- chooser.chooseDirectory[ErrorChannel]("Select Map Editor export directory")
+      destEC <- chooser.chooseDirectory[ErrorChannel]("Select Dominions map input directory")
+      written <- (sourceEC, destEC).tupled.traverse { case (source, dest) =>
+        val configPath = NioPath.of(configFileName)
+        val contents =
+          s"""source="${source.toString}"
+dest="${dest.toString}"
+"""
+        (for
+          exists <- Async[Sequencer].delay(JFiles.exists(configPath))
+          _ <-
+            if exists then Async[Sequencer].unit
+            else Async[Sequencer].delay(JFiles.createFile(configPath)).void
+          _ <- Async[Sequencer].delay(JFiles.writeString(configPath, contents))
+        yield ()).attempt.map(
+          _.fold(
+            e => errorChannel.raiseError[Unit](e),
+            _ => errorChannel.pure(())
+          )
+        )
+      }
+    yield errorChannel.flatMap(written)(x => x)

--- a/documentation/engineering/architecture/map_editor_pipeline.md
+++ b/documentation/engineering/architecture/map_editor_pipeline.md
@@ -81,5 +81,8 @@ This document captures the initial plan for processing map-editor directories an
 - Implementations should provide concrete filesystem and parsing behavior while respecting the project's error-handling guidelines.
 - A composite `MapProcessingService` orchestrates the overall workflow by delegating to these capabilities, preserving modularity and SOLID design.
 
+## Configuration
+- [Directory Configuration Service](../directory_configuration_service.md) captures user-selected directories and persists them to `map-editor-wrap.conf`.
+
 ## Testing
 - `sbt compile`

--- a/documentation/engineering/directory_configuration_service.md
+++ b/documentation/engineering/directory_configuration_service.md
@@ -1,0 +1,21 @@
+# Directory Configuration Service
+
+This document describes the services that allow a user to select the map editor
+export directory and the Dominions map input directory.
+
+## Components
+- **DirectoryChooser** – launches a `JFileChooser` restricted to directories. It
+  exposes a `chooseDirectory` method returning the selected path or an error in
+  the effect channel.
+- **DirectoryConfigService** – orchestrates two directory selections (export and
+  input) and persists the results to `map-editor-wrap.conf`, creating the file
+  when necessary.
+
+## Design Notes
+- UI concerns are isolated in `DirectoryChooserImpl`; other services remain free
+  of Swing dependencies so the rendering layer can be replaced later.
+- All effects follow the `Sequencer`/`ErrorChannel` pattern outlined in the
+  architecture guides.
+
+## Testing
+- `sbt compile`


### PR DESCRIPTION
Summary:
- add DirectoryChooser capability and DirectoryConfigService to prompt for map directories and save selections
- document directory configuration service and link from AGENTS and map editor pipeline

Testing Done:
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_6897de5082848327a832badb9555c407