### PR TITLE
Feature: Ground-surface duel service

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceDuelPipe.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceDuelPipe.scala
@@ -1,0 +1,56 @@
+package com.crib.bills.dom6maps
+package apps.services.mapeditor
+
+import cats.{MonadError, Traverse, Applicative}
+import cats.syntax.all.*
+import fs2.Stream
+import model.map.*
+
+trait GroundSurfaceDuelPipe[Sequencer[_]]:
+  def apply[ErrorChannel[_]](
+      surface: Stream[Sequencer, MapDirective],
+      cave: Stream[Sequencer, MapDirective],
+      config: GroundSurfaceDuelConfig
+    )(using MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+    ): Sequencer[ErrorChannel[(Vector[MapDirective], Vector[MapDirective])]]
+
+class GroundSurfaceDuelPipeImpl[Sequencer[_]: cats.effect.Sync](
+    sizeValidator: MapSizeValidator[Sequencer],
+    planner: PlacementPlanner[Sequencer],
+    gateService: GateDirectiveService[Sequencer],
+    throneService: ThronePlacementService[Sequencer]
+) extends GroundSurfaceDuelPipe[Sequencer]:
+  override def apply[ErrorChannel[_]](
+      surface: Stream[Sequencer, MapDirective],
+      cave: Stream[Sequencer, MapDirective],
+      config: GroundSurfaceDuelConfig
+    )(using errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+    ): Sequencer[ErrorChannel[(Vector[MapDirective], Vector[MapDirective])]] =
+    for
+      validated <- sizeValidator.validate[ErrorChannel](surface, cave)
+      result <- validated.traverse { case (size, surfaceDs, caveDs) =>
+        val (gates, thrones) = planner.plan(size, config)
+        val width = MapWidth(size.value)
+        val height = MapHeight(size.value)
+        val transform = (ds: Vector[MapDirective]) =>
+          Stream
+            .emits(ds)
+            .covary[Sequencer]
+            .through(gateService.pipe(gates))
+            .through(throneService.pipe(thrones))
+            .through(WrapSeverService.verticalPipe(width, height))
+            .through(WrapSeverService.horizontalPipe(width, height))
+            .compile
+            .toVector
+        (transform(surfaceDs), transform(caveDs)).tupled
+      }
+    yield result
+
+class GroundSurfaceDuelPipeStub[Sequencer[_]: Applicative] extends GroundSurfaceDuelPipe[Sequencer]:
+  override def apply[ErrorChannel[_]](
+      surface: Stream[Sequencer, MapDirective],
+      cave: Stream[Sequencer, MapDirective],
+      config: GroundSurfaceDuelConfig
+    )(using MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+    ): Sequencer[ErrorChannel[(Vector[MapDirective], Vector[MapDirective])]] =
+    (Vector.empty[MapDirective], Vector.empty[MapDirective]).pure[ErrorChannel].pure[Sequencer]

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapSizeValidator.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapSizeValidator.scala
@@ -1,0 +1,49 @@
+package com.crib.bills.dom6maps
+package apps.services.mapeditor
+
+import cats.{MonadError, Traverse, Applicative}
+import cats.syntax.all.*
+import fs2.Stream
+import model.map.*
+
+trait MapSizeValidator[Sequencer[_]]:
+  def validate[ErrorChannel[_]](
+      surface: Stream[Sequencer, MapDirective],
+      cave: Stream[Sequencer, MapDirective]
+    )(using MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+    ): Sequencer[ErrorChannel[(MapSize, Vector[MapDirective], Vector[MapDirective])]]
+
+class MapSizeValidatorImpl[Sequencer[_]: cats.effect.Sync] extends MapSizeValidator[Sequencer]:
+  override def validate[ErrorChannel[_]](
+      surface: Stream[Sequencer, MapDirective],
+      cave: Stream[Sequencer, MapDirective]
+    )(using errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+    ): Sequencer[ErrorChannel[(MapSize, Vector[MapDirective], Vector[MapDirective])]] =
+    for
+      surfaceDirectives <- surface.compile.toVector
+      caveDirectives    <- cave.compile.toVector
+    yield
+      val surfSize = surfaceDirectives.collectFirst { case m: MapSizePixels => m.toProvinceSize }
+      val caveSize = caveDirectives.collectFirst { case m: MapSizePixels => m.toProvinceSize }
+      val result = (surfSize, caveSize) match
+        case (
+              Some(ProvinceSize(MapWidth(sw), MapHeight(sh))),
+              Some(ProvinceSize(MapWidth(cw), MapHeight(ch)))
+            ) =>
+          if sw != sh || cw != ch || sw != cw then
+            Left(IllegalArgumentException("Map dimensions must be equal, square, and odd"))
+          else MapSize.from(sw).map(ms => (ms, surfaceDirectives, caveDirectives))
+        case _ => Left(IllegalArgumentException("Map size directive missing"))
+      errorChannel.fromEither(result)
+
+class MapSizeValidatorStub[Sequencer[_]: Applicative](
+    size: MapSize,
+    surfaceDirectives: Vector[MapDirective],
+    caveDirectives: Vector[MapDirective]
+) extends MapSizeValidator[Sequencer]:
+  override def validate[ErrorChannel[_]](
+      surface: Stream[Sequencer, MapDirective],
+      cave: Stream[Sequencer, MapDirective]
+    )(using MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+    ): Sequencer[ErrorChannel[(MapSize, Vector[MapDirective], Vector[MapDirective])]] =
+    (size, surfaceDirectives, caveDirectives).pure[ErrorChannel].pure[Sequencer]

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/PlacementPlanner.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/PlacementPlanner.scala
@@ -1,0 +1,30 @@
+package com.crib.bills.dom6maps
+package apps.services.mapeditor
+
+import model.ProvinceId
+import model.map.*
+
+trait PlacementPlanner[Sequencer[_]]:
+  def plan(size: MapSize, config: GroundSurfaceDuelConfig): (Vector[GateSpec], Vector[ThronePlacement])
+
+class PlacementPlannerImpl[Sequencer[_]] extends PlacementPlanner[Sequencer]:
+  override def plan(size: MapSize, config: GroundSurfaceDuelConfig): (Vector[GateSpec], Vector[ThronePlacement]) =
+    val mids = EdgeMidpoints.of(size)
+    val corners = CornerProvinces.all(size)
+    val offset = size.value * size.value
+    val gates = Vector(
+      GateSpec(mids.top, ProvinceId(mids.top.value + offset)),
+      GateSpec(mids.bottom, ProvinceId(mids.bottom.value + offset)),
+      GateSpec(mids.left, ProvinceId(mids.left.value + offset)),
+      GateSpec(mids.right, ProvinceId(mids.right.value + offset))
+    )
+    val level = config.throneLevel
+    val thrones = corners.map(p => ThronePlacement(p, level))
+    (gates, thrones)
+
+class PlacementPlannerStub[Sequencer[_]](
+    gates: Vector[GateSpec],
+    thrones: Vector[ThronePlacement]
+) extends PlacementPlanner[Sequencer]:
+  override def plan(size: MapSize, config: GroundSurfaceDuelConfig): (Vector[GateSpec], Vector[ThronePlacement]) =
+    (gates, thrones)

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceDuelPipeSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceDuelPipeSpec.scala
@@ -1,0 +1,72 @@
+package com.crib.bills.dom6maps
+package services.mapeditor
+
+import cats.effect.IO
+import fs2.Stream
+import weaver.SimpleIOSuite
+import cats.syntax.all.*
+import model.ProvinceId
+import model.TerrainFlag
+import model.TerrainMask
+import model.map.*
+
+object GroundSurfaceDuelPipeSpec extends SimpleIOSuite:
+  private def mapSizeDirective = MapSizePixels(MapWidthPixels(5 * 256), MapHeightPixels(5 * 160))
+
+  test("pipe adds gates, thrones, and severs wrap"):
+    val surface = Vector(
+      mapSizeDirective,
+      WrapAround,
+      Gate(ProvinceId(1), ProvinceId(2)),
+      Terrain(ProvinceId(1), 0),
+      Terrain(ProvinceId(5), 0),
+      Terrain(ProvinceId(21), 0),
+      Terrain(ProvinceId(25), 0)
+    )
+    val cave = Vector(
+      mapSizeDirective,
+      WrapAround,
+      Gate(ProvinceId(2), ProvinceId(3)),
+      Terrain(ProvinceId(1), 0),
+      Terrain(ProvinceId(5), 0),
+      Terrain(ProvinceId(21), 0),
+      Terrain(ProvinceId(25), 0)
+    )
+    import cats.instances.either.*
+    type EC[A] = Either[Throwable, A]
+    val pipe = new apps.services.mapeditor.GroundSurfaceDuelPipeImpl[IO](
+      new apps.services.mapeditor.MapSizeValidatorImpl[IO],
+      new apps.services.mapeditor.PlacementPlannerImpl[IO],
+      new apps.services.mapeditor.GateDirectiveServiceImpl[IO],
+      new apps.services.mapeditor.ThronePlacementServiceImpl[IO]
+    )
+    val res = pipe.apply[EC](Stream.emits(surface), Stream.emits(cave), GroundSurfaceDuelConfig.default)
+    res.flatMap { ec =>
+      IO.fromEither(ec.map { case (surfRes, caveRes) =>
+        val gates = Vector(
+          Gate(ProvinceId(3), ProvinceId(28)),
+          Gate(ProvinceId(23), ProvinceId(48)),
+          Gate(ProvinceId(11), ProvinceId(36)),
+          Gate(ProvinceId(15), ProvinceId(40))
+        )
+        val thrones = Vector(1, 5, 21, 25).map(ProvinceId.apply)
+        def hasThrones(ds: Vector[MapDirective]) =
+          thrones.forall { id =>
+            ds.exists {
+              case Terrain(p, m) if p == id => TerrainMask(m).hasFlag(TerrainFlag.Throne)
+              case _                         => false
+            }
+          }
+        val surfChecks =
+          gates.forall(surfRes.contains) &&
+            hasThrones(surfRes) &&
+            !surfRes.exists { case Gate(ProvinceId(1), ProvinceId(2)) => true; case _ => false } &&
+            !surfRes.contains(WrapAround) && surfRes.contains(NoWrapAround)
+        val caveChecks =
+          gates.forall(caveRes.contains) &&
+            hasThrones(caveRes) &&
+            !caveRes.exists { case Gate(ProvinceId(2), ProvinceId(3)) => true; case _ => false } &&
+            !caveRes.contains(WrapAround) && caveRes.contains(NoWrapAround)
+        expect(surfChecks && caveChecks)
+      })
+    }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/PlacementPlannerSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/PlacementPlannerSpec.scala
@@ -1,0 +1,24 @@
+package com.crib.bills.dom6maps
+package services.mapeditor
+
+import cats.effect.IO
+import cats.syntax.all.*
+import weaver.SimpleIOSuite
+import model.ProvinceId
+import model.map.*
+
+object PlacementPlannerSpec extends SimpleIOSuite:
+  test("planner computes gates and thrones") {
+    val planner = new apps.services.mapeditor.PlacementPlannerImpl[IO]
+    val size = MapSize.from(5).toOption.get
+    val config = GroundSurfaceDuelConfig.default
+    val (gates, thrones) = planner.plan(size, config)
+    val expectedGates = Vector(
+      GateSpec(ProvinceId(3), ProvinceId(28)),
+      GateSpec(ProvinceId(23), ProvinceId(48)),
+      GateSpec(ProvinceId(11), ProvinceId(36)),
+      GateSpec(ProvinceId(15), ProvinceId(40))
+    )
+    val expectedThrones = Vector(1, 5, 21, 25).map(p => ThronePlacement(ProvinceId(p), ThroneLevel(1)))
+    expect(gates == expectedGates && thrones == expectedThrones).pure[IO]
+  }

--- a/documentation/engineering/architecture/ground_surface_duel_service.md
+++ b/documentation/engineering/architecture/ground_surface_duel_service.md
@@ -14,11 +14,11 @@ The Ground-Surface Duel service composes map modification capabilities to genera
 - `MapSize`: value class wrapping an odd `Int` side length with constructor validation.
 - `EdgeMidpoints`: pure function computing midpoint province identifiers for a given `MapSize`.
 - `CornerProvinces`: pure function returning the four corner province identifiers.
-- `GroundSurfaceDuelConfig`: optional throne level and additional gate settings for future extension.
+- `GroundSurfaceDuelConfig`: throne level (default `ThroneLevel(1)`) and hooks for future extension.
 
 ## Capability Sketches
 1. **MapSizeValidator**
-   - Computes map dimensions from a directive stream.
+   - Computes map dimensions from directive streams and returns the compiled directives.
    - Ensures both layers are equal, square, and odd-sized.
 2. **PlacementPlanner**
    - Uses `MapSize` to derive:
@@ -35,7 +35,7 @@ The Ground-Surface Duel service composes map modification capabilities to genera
          cave: Stream[Sequencer, MapDirective],
          config: GroundSurfaceDuelConfig
        )(using
-         errorChannel: MonadError[ErrorChannel, status.Error] & Traverse[ErrorChannel]
+         errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
        ): Sequencer[ErrorChannel[(Vector[MapDirective], Vector[MapDirective])]]
      ```
    - Internally invokes:

--- a/model/src/main/scala/model/map/CornerProvinces.scala
+++ b/model/src/main/scala/model/map/CornerProvinces.scala
@@ -1,0 +1,19 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import model.ProvinceId
+
+final case class CornerProvinces(topLeft: ProvinceId, topRight: ProvinceId, bottomLeft: ProvinceId, bottomRight: ProvinceId)
+
+object CornerProvinces:
+  def of(size: MapSize): CornerProvinces =
+    val n = size.value
+    val topLeft = ProvinceId(1)
+    val topRight = ProvinceId(n)
+    val bottomLeft = ProvinceId((n - 1) * n + 1)
+    val bottomRight = ProvinceId(n * n)
+    CornerProvinces(topLeft, topRight, bottomLeft, bottomRight)
+
+  def all(size: MapSize): Vector[ProvinceId] =
+    val c = of(size)
+    Vector(c.topLeft, c.topRight, c.bottomLeft, c.bottomRight)

--- a/model/src/main/scala/model/map/EdgeMidpoints.scala
+++ b/model/src/main/scala/model/map/EdgeMidpoints.scala
@@ -1,0 +1,16 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import model.ProvinceId
+
+final case class EdgeMidpoints(top: ProvinceId, bottom: ProvinceId, left: ProvinceId, right: ProvinceId)
+
+object EdgeMidpoints:
+  def of(size: MapSize): EdgeMidpoints =
+    val n = size.value
+    val mid = (n + 1) / 2
+    val top = ProvinceId(mid)
+    val bottom = ProvinceId((n - 1) * n + mid)
+    val left = ProvinceId((mid - 1) * n + 1)
+    val right = ProvinceId((mid - 1) * n + n)
+    EdgeMidpoints(top, bottom, left, right)

--- a/model/src/main/scala/model/map/GroundSurfaceDuelConfig.scala
+++ b/model/src/main/scala/model/map/GroundSurfaceDuelConfig.scala
@@ -1,0 +1,7 @@
+package com.crib.bills.dom6maps
+package model.map
+
+final case class GroundSurfaceDuelConfig(throneLevel: ThroneLevel)
+
+object GroundSurfaceDuelConfig:
+  val default: GroundSurfaceDuelConfig = GroundSurfaceDuelConfig(ThroneLevel(1))

--- a/model/src/main/scala/model/map/MapSize.scala
+++ b/model/src/main/scala/model/map/MapSize.scala
@@ -1,0 +1,10 @@
+package com.crib.bills.dom6maps
+package model.map
+
+/** Square map side length. Must be positive and odd. */
+final case class MapSize private (value: Int) extends AnyVal
+
+object MapSize:
+  def from(value: Int): Either[Throwable, MapSize] =
+    if value > 0 && value % 2 == 1 then Right(MapSize(value))
+    else Left(IllegalArgumentException("MapSize must be positive and odd"))


### PR DESCRIPTION
## Summary
- add map size domain and helpers for edge midpoints and corners
- implement MapSizeValidator, PlacementPlanner, and GroundSurfaceDuelPipe
- document ground-surface duel service architecture

## Testing
- `sbt compile`
- `sbt "project apps" test`


------
https://chatgpt.com/codex/tasks/task_b_689933f2eb4883279be886cf04aab803