### PR TITLE
Feature: Ground-surface duel nation selection

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorWrapApp.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/apps/MapEditorWrapApp.scala
@@ -18,6 +18,9 @@ import services.mapeditor.{
   PlacementPlannerImpl,
   GateDirectiveServiceImpl,
   ThronePlacementServiceImpl,
+  GroundSurfaceNationServiceImpl,
+  GroundSurfaceNationService,
+  SpawnPlacementServiceImpl,
   GroundSurfaceDuelPipe
 }
 import services.update.GithubReleaseCheckerImpl
@@ -33,14 +36,18 @@ dest="/path/to/dominions/maps"
 
   private val currentVersion = Version("1.1")
 
-  def runWith(chooser: WrapChoiceService[IO], dueler: GroundSurfaceDuelPipe[IO]): IO[ExitCode] =
+  def runWith(
+      chooser: WrapChoiceService[IO],
+      nationChooser: GroundSurfaceNationService[IO],
+      dueler: GroundSurfaceDuelPipe[IO]
+  ): IO[ExitCode] =
     val finder = new LatestEditorFinderImpl[IO]
     val copier = new MapEditorCopierImpl[IO]
     val writer = new MapWriterImpl[IO]
     val converter = new WrapConversionServiceImpl[IO]
     val checker = new GithubReleaseCheckerImpl[IO]
     val workflow =
-      new MapWrapWorkflowImpl(finder, copier, writer, converter, checker, chooser, dueler, currentVersion)
+      new MapWrapWorkflowImpl(finder, copier, writer, converter, checker, chooser, nationChooser, dueler, currentVersion)
     val action =
       for
         exists <- IO(JFiles.exists(NioPath.of(configFileName)))
@@ -59,6 +66,7 @@ dest="/path/to/dominions/maps"
       new MapSizeValidatorImpl[IO],
       new PlacementPlannerImpl[IO],
       new GateDirectiveServiceImpl[IO],
-      new ThronePlacementServiceImpl[IO]
+      new ThronePlacementServiceImpl[IO],
+      new SpawnPlacementServiceImpl[IO]
     )
-    runWith(new WrapChoiceServiceImpl[IO], dueler)
+    runWith(new WrapChoiceServiceImpl[IO], new GroundSurfaceNationServiceImpl[IO], dueler)

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceNationPanel.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceNationPanel.scala
@@ -1,0 +1,18 @@
+package com.crib.bills.dom6maps
+package apps.services.mapeditor
+
+import javax.swing.{JComboBox, JLabel, JPanel}
+import model.Nation
+
+final class GroundSurfaceNationPanel(defaultSurface: Nation, defaultUnderground: Nation) extends JPanel:
+  private val surfaceBox = new JComboBox[Nation](Nation.values)
+  private val undergroundBox = new JComboBox[Nation](Nation.values)
+  surfaceBox.setSelectedItem(defaultSurface)
+  undergroundBox.setSelectedItem(defaultUnderground)
+  add(new JLabel("surface nation"))
+  add(surfaceBox)
+  add(new JLabel("underground nation"))
+  add(undergroundBox)
+
+  def surface: Nation = surfaceBox.getItemAt(surfaceBox.getSelectedIndex)
+  def underground: Nation = undergroundBox.getItemAt(undergroundBox.getSelectedIndex)

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceNationService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceNationService.scala
@@ -1,0 +1,35 @@
+package com.crib.bills.dom6maps
+package apps.services.mapeditor
+
+import cats.{MonadError, Traverse}
+import cats.effect.Sync
+import cats.syntax.all.*
+import javax.swing.{JOptionPane}
+import model.map.{SurfaceNation, UndergroundNation, DuelNations}
+import model.Nation
+
+trait GroundSurfaceNationService[Sequencer[_]]:
+  def chooseNations[ErrorChannel[_]]()(using
+      MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+  ): Sequencer[ErrorChannel[DuelNations]]
+
+class GroundSurfaceNationServiceImpl[Sequencer[_]](using Sync[Sequencer])
+    extends GroundSurfaceNationService[Sequencer]:
+  override def chooseNations[ErrorChannel[_]]()(using
+      errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+  ): Sequencer[ErrorChannel[DuelNations]] =
+    Sync[Sequencer].delay {
+      val panel = new GroundSurfaceNationPanel(Nation.Agartha_Early, Nation.Agartha_Early)
+      val result = JOptionPane.showConfirmDialog(
+        null,
+        panel,
+        "Select nations",
+        JOptionPane.OK_CANCEL_OPTION,
+        JOptionPane.PLAIN_MESSAGE
+      )
+      if result == JOptionPane.OK_OPTION then
+        val surface = SurfaceNation(panel.surface)
+        val underground = UndergroundNation(panel.underground)
+        errorChannel.pure(DuelNations(surface, underground))
+      else errorChannel.raiseError[DuelNations](RuntimeException("Nation selection cancelled"))
+    }

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/SpawnPlacementService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/SpawnPlacementService.scala
@@ -1,0 +1,26 @@
+package com.crib.bills.dom6maps
+package apps.services.mapeditor
+
+import cats.Applicative
+import fs2.{Pipe, Stream}
+import model.map.{MapDirective, PlayerSpawn, AllowedPlayer, SpecStart}
+
+trait SpawnPlacementService[Sequencer[_]]:
+  def pipe(spawns: Vector[PlayerSpawn]): Pipe[Sequencer, MapDirective, MapDirective]
+
+class SpawnPlacementServiceImpl[Sequencer[_]] extends SpawnPlacementService[Sequencer]:
+  override def pipe(spawns: Vector[PlayerSpawn]): Pipe[Sequencer, MapDirective, MapDirective] =
+    in =>
+      val cleaned = in.filter {
+        case _: AllowedPlayer => false
+        case _: SpecStart     => false
+        case _                => true
+      }
+      val additions = Stream
+        .emits(spawns.flatMap(s => Vector(AllowedPlayer(s.nation), SpecStart(s.nation, s.province))))
+        .covary[Sequencer]
+      cleaned ++ additions
+
+class SpawnPlacementServiceStub[Sequencer[_]: Applicative] extends SpawnPlacementService[Sequencer]:
+  override def pipe(spawns: Vector[PlayerSpawn]): Pipe[Sequencer, MapDirective, MapDirective] =
+    stream => stream

--- a/model/src/main/scala/model/map/CenterProvince.scala
+++ b/model/src/main/scala/model/map/CenterProvince.scala
@@ -1,0 +1,10 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import model.ProvinceId
+
+object CenterProvince:
+  def of(size: MapSize): ProvinceId =
+    val n = size.value
+    val mid = (n + 1) / 2
+    ProvinceId((mid - 1) * n + mid)

--- a/model/src/main/scala/model/map/DuelNations.scala
+++ b/model/src/main/scala/model/map/DuelNations.scala
@@ -1,0 +1,8 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import model.Nation
+
+final case class SurfaceNation(value: Nation) extends AnyVal
+final case class UndergroundNation(value: Nation) extends AnyVal
+final case class DuelNations(surface: SurfaceNation, underground: UndergroundNation)

--- a/model/src/main/scala/model/map/PlayerSpawn.scala
+++ b/model/src/main/scala/model/map/PlayerSpawn.scala
@@ -1,0 +1,6 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import model.{Nation, ProvinceId}
+
+final case class PlayerSpawn(nation: Nation, province: ProvinceId)


### PR DESCRIPTION
## Summary
- prompt user for surface and underground nations before generating a ground-surface duel map
- spawn each player in the center of their respective layer while cleaning existing spawn data
- document duel pipeline to include nation inputs and spawn placement

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_b_689940f26c34832792c0de6b90956514