### PR TITLE
Feature: Map state scaffold

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val commonSettings = Seq(
 lazy val model = (project in file("model"))
   .settings(
     name := "model",
-    libraryDependencies ++= Dependencies.core,
+    libraryDependencies ++= Dependencies.core ++ Dependencies.tests.map(_ % Test),
     commonSettings
   )
 

--- a/documentation/engineering/architecture/README.md
+++ b/documentation/engineering/architecture/README.md
@@ -21,4 +21,5 @@ Item 2, the effect patterns are mandatory reading if you plan on writing code. I
 12. [Map Editor Processing Pipeline](map_editor_pipeline.md)
 13. [Map Modification Services](map_modification_services.md)
 14. [Ground-Surface Duel Service](ground_surface_duel_service.md)
-15. [Map State Model Migration Plan](map_state_model_migration.md)
+15. [Map State](map_state.md)
+16. [Map State Model Migration Plan](map_state_model_migration.md)

--- a/documentation/engineering/architecture/map_state.md
+++ b/documentation/engineering/architecture/map_state.md
@@ -1,0 +1,15 @@
+# Map State
+
+`MapState` captures high level map metadata derived from parsed directives while omitting heavy payloads such as province pixel data.
+
+## Fields
+- `size` – square dimension in provinces.
+- `adjacency` – placeholder collection of province connections.
+- `borders` – connections carrying a `BorderFlag` from `#neighbourspec`.
+- `wrap` – horizontal and/or vertical wrapping behaviour.
+- `title` and `description` – human readable metadata.
+- `allowedPlayers` and `startingPositions` – player nation and starting province pairs.
+- `terrains` – terrain masks for provinces.
+- `gates` – special province links.
+
+The companion object provides `fromDirectives` which folds a stream of `MapDirective` values to populate these fields.

--- a/documentation/engineering/architecture/map_state_model_migration.md
+++ b/documentation/engineering/architecture/map_state_model_migration.md
@@ -13,7 +13,7 @@ This document outlines how to evolve the map editing pipeline to use a compact `
 1. **Directive Events** – sealed hierarchy representing parsed directives:
    - Known events: `MapSize`, `ProvinceAt`, `Adjacency`, `ImageRow`, `Comment`.
    - Unknown lines preserved as `UnknownDirective`.
-2. **MapState** – authoritative facts derived from events:
+2. **[MapState](map_state.md)** – authoritative facts derived from events:
    - Map dimensions.
    - Vector of province locations.
    - Adjacency graph.

--- a/model/src/main/scala/model/map/MapState.scala
+++ b/model/src/main/scala/model/map/MapState.scala
@@ -1,0 +1,80 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import cats.effect.kernel.Concurrent
+import fs2.Stream
+import model.{BorderFlag, ProvinceId}
+
+enum WrapState:
+  case NoWrap, HorizontalWrap, VerticalWrap, FullWrap
+
+final case class Border(a: ProvinceId, b: ProvinceId, flag: BorderFlag)
+final case class MapTitle(value: String) extends AnyVal
+final case class MapDescription(value: String) extends AnyVal
+
+final case class MapState(
+    size: Option[MapSize],
+    adjacency: Vector[(ProvinceId, ProvinceId)],
+    borders: Vector[Border],
+    wrap: WrapState,
+    title: Option[MapTitle],
+    description: Option[MapDescription],
+    allowedPlayers: Vector[AllowedPlayer],
+    startingPositions: Vector[SpecStart],
+    terrains: Vector[Terrain],
+    gates: Vector[Gate]
+)
+
+object MapState:
+  val empty: MapState = MapState(
+    None,
+    Vector.empty,
+    Vector.empty,
+    WrapState.NoWrap,
+    None,
+    None,
+    Vector.empty,
+    Vector.empty,
+    Vector.empty,
+    Vector.empty
+  )
+
+  def fromDirectives[F[_]: Concurrent](directives: Stream[F, MapDirective]): F[MapState] =
+    directives.compile.fold(empty)(accumulate)
+
+  private def accumulate(state: MapState, directive: MapDirective): MapState =
+    directive match
+      case m: MapSizePixels =>
+        val width = m.toProvinceSize.width.value
+        MapSize.from(width).toOption match
+          case Some(sz) => state.copy(size = Some(sz))
+          case None     => state
+      case Dom2Title(t) =>
+        state.copy(title = Some(MapTitle(t)))
+      case Description(d) =>
+        state.copy(description = Some(MapDescription(d)))
+      case WrapAround =>
+        state.copy(wrap = WrapState.FullWrap)
+      case HWrapAround =>
+        state.copy(wrap = WrapState.HorizontalWrap)
+      case VWrapAround =>
+        state.copy(wrap = WrapState.VerticalWrap)
+      case NoWrapAround =>
+        state.copy(wrap = WrapState.NoWrap)
+      case ap: AllowedPlayer =>
+        state.copy(allowedPlayers = state.allowedPlayers :+ ap)
+      case ss: SpecStart =>
+        state.copy(startingPositions = state.startingPositions :+ ss)
+      case t: Terrain =>
+        state.copy(terrains = state.terrains :+ t)
+      case g: Gate =>
+        state.copy(gates = state.gates :+ g)
+      case Neighbour(a, b) =>
+        state.copy(adjacency = state.adjacency :+ ((a, b)))
+      case NeighbourSpec(a, b, f) =>
+        state.copy(
+          adjacency = state.adjacency :+ ((a, b)),
+          borders = state.borders :+ Border(a, b, f)
+        )
+      case _ =>
+        state

--- a/model/src/test/scala/model/map/MapStateSpec.scala
+++ b/model/src/test/scala/model/map/MapStateSpec.scala
@@ -1,0 +1,44 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import cats.effect.IO
+import fs2.Stream
+import weaver.SimpleIOSuite
+import model.{ProvinceId, BorderFlag, Nation}
+
+object MapStateSpec extends SimpleIOSuite:
+  private val directives = Vector(
+    MapSizePixels(MapWidthPixels(1280), MapHeightPixels(800)),
+    Dom2Title("T"),
+    Description("D"),
+    HWrapAround,
+    AllowedPlayer(Nation.Atlantis_Early),
+    SpecStart(Nation.Atlantis_Early, ProvinceId(42)),
+    Terrain(ProvinceId(5), 7),
+    Gate(ProvinceId(1), ProvinceId(2)),
+    Neighbour(ProvinceId(3), ProvinceId(4)),
+    NeighbourSpec(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)
+  )
+
+  test("builds map state from directives") {
+    MapState.fromDirectives(Stream.emits(directives).covary[IO]).map { state =>
+      val expected = MapState(
+        size = MapSize.from(5).toOption,
+        adjacency = Vector(
+          (ProvinceId(3), ProvinceId(4)),
+          (ProvinceId(5), ProvinceId(6))
+        ),
+        borders = Vector(
+          Border(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)
+        ),
+        wrap = WrapState.HorizontalWrap,
+        title = Some(MapTitle("T")),
+        description = Some(MapDescription("D")),
+        allowedPlayers = Vector(AllowedPlayer(Nation.Atlantis_Early)),
+        startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
+        terrains = Vector(Terrain(ProvinceId(5), 7)),
+        gates = Vector(Gate(ProvinceId(1), ProvinceId(2)))
+      )
+      expect(state == expected)
+    }
+  }


### PR DESCRIPTION
## Summary
- add MapState model with wrap, metadata, and adjacency placeholders
- fold directive streams into MapState
- document MapState and link in architecture guides

## Testing
- `sbt "project model" test`
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_689a352375808327a1eced6f57cb76ab