### PR TITLE
Feature: Map state encoders

### DIFF
--- a/documentation/engineering/architecture/map_state.md
+++ b/documentation/engineering/architecture/map_state.md
@@ -13,3 +13,5 @@
 - `gates` – special province links.
 
 The companion object provides `fromDirectives` which folds a stream of `MapDirective` values to populate these fields.
+
+`MapDirectiveCodecs` supplies the inverse operation by encoding `MapState` and its components back into canonical `MapDirective` values.

--- a/model/src/main/scala/model/map/MapDirectiveCodecs.scala
+++ b/model/src/main/scala/model/map/MapDirectiveCodecs.scala
@@ -1,0 +1,84 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import model.{ProvinceId, BorderFlag}
+
+object MapDirectiveCodecs:
+  trait Encoder[A]:
+    def encode(value: A): Vector[MapDirective]
+
+  object Encoder:
+    def apply[A](using enc: Encoder[A]) = enc
+
+    extension [A](value: A)(using enc: Encoder[A])
+      def toDirectives: Vector[MapDirective] = enc.encode(value)
+
+  import Encoder.*
+
+  given Encoder[MapSize] with
+    def encode(value: MapSize): Vector[MapDirective] =
+      Vector(
+        MapSizePixels(
+          MapWidthPixels(value.value * 256),
+          MapHeightPixels(value.value * 160)
+        )
+      )
+
+  given Encoder[WrapState] with
+    def encode(value: WrapState): Vector[MapDirective] =
+      Vector(
+        value match
+          case WrapState.FullWrap       => WrapAround
+          case WrapState.HorizontalWrap => HWrapAround
+          case WrapState.VerticalWrap   => VWrapAround
+          case WrapState.NoWrap         => NoWrapAround
+      )
+
+  given Encoder[MapTitle] with
+    def encode(value: MapTitle): Vector[MapDirective] =
+      Vector(Dom2Title(value.value))
+
+  given Encoder[MapDescription] with
+    def encode(value: MapDescription): Vector[MapDirective] =
+      Vector(Description(value.value))
+
+  given Encoder[AllowedPlayer] with
+    def encode(value: AllowedPlayer): Vector[MapDirective] =
+      Vector(value)
+
+  given Encoder[SpecStart] with
+    def encode(value: SpecStart): Vector[MapDirective] =
+      Vector(value)
+
+  given Encoder[Terrain] with
+    def encode(value: Terrain): Vector[MapDirective] =
+      Vector(value)
+
+  given Encoder[Gate] with
+    def encode(value: Gate): Vector[MapDirective] =
+      Vector(value)
+
+  given Encoder[(ProvinceId, ProvinceId)] with
+    def encode(value: (ProvinceId, ProvinceId)): Vector[MapDirective] =
+      Vector(Neighbour(value._1, value._2))
+
+  given Encoder[Border] with
+    def encode(value: Border): Vector[MapDirective] =
+      Vector(NeighbourSpec(value.a, value.b, value.flag))
+
+  given Encoder[MapState] with
+    def encode(value: MapState): Vector[MapDirective] =
+      val size = value.size.toVector.flatMap(Encoder[MapSize].encode)
+      val wrap = Encoder[WrapState].encode(value.wrap)
+      val title = value.title.toVector.flatMap(Encoder[MapTitle].encode)
+      val description = value.description.toVector.flatMap(Encoder[MapDescription].encode)
+      val players = value.allowedPlayers.flatMap(Encoder[AllowedPlayer].encode)
+      val starts = value.startingPositions.flatMap(Encoder[SpecStart].encode)
+      val terrains = value.terrains.flatMap(Encoder[Terrain].encode)
+      val gates = value.gates.flatMap(Encoder[Gate].encode)
+      val borderPairs = value.borders.map(b => (b.a, b.b)).toSet
+      val adjacency = value.adjacency
+        .filterNot(borderPairs.contains)
+        .flatMap(Encoder[(ProvinceId, ProvinceId)].encode)
+      val borders = value.borders.flatMap(Encoder[Border].encode)
+      size ++ wrap ++ title ++ description ++ players ++ starts ++ terrains ++ gates ++ adjacency ++ borders

--- a/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
+++ b/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
@@ -1,0 +1,42 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import cats.effect.IO
+import weaver.SimpleIOSuite
+import model.{ProvinceId, BorderFlag, Nation}
+import MapDirectiveCodecs.given
+import MapDirectiveCodecs.Encoder
+
+object MapDirectiveCodecsSpec extends SimpleIOSuite:
+  test("encodes map state to directives") {
+    val state = MapState(
+      size = MapSize.from(5).toOption,
+      adjacency = Vector(
+        (ProvinceId(3), ProvinceId(4)),
+        (ProvinceId(5), ProvinceId(6))
+      ),
+      borders = Vector(Border(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)),
+      wrap = WrapState.HorizontalWrap,
+      title = Some(MapTitle("T")),
+      description = Some(MapDescription("D")),
+      allowedPlayers = Vector(AllowedPlayer(Nation.Atlantis_Early)),
+      startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
+      terrains = Vector(Terrain(ProvinceId(5), 7)),
+      gates = Vector(Gate(ProvinceId(1), ProvinceId(2)))
+    )
+
+    val expected = Vector(
+      MapSizePixels(MapWidthPixels(1280), MapHeightPixels(800)),
+      HWrapAround,
+      Dom2Title("T"),
+      Description("D"),
+      AllowedPlayer(Nation.Atlantis_Early),
+      SpecStart(Nation.Atlantis_Early, ProvinceId(42)),
+      Terrain(ProvinceId(5), 7),
+      Gate(ProvinceId(1), ProvinceId(2)),
+      Neighbour(ProvinceId(3), ProvinceId(4)),
+      NeighbourSpec(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)
+    )
+
+    IO.pure(expect(Encoder[MapState].encode(state) == expected))
+  }


### PR DESCRIPTION
## Summary
- add encoders for individual map state components and a total map state encoder
- document reverse conversion from map state back to directives

## Testing
- `sbt "project model" "testOnly com.crib.bills.dom6maps.model.map.MapDirectiveCodecsSpec"`
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_689a47807db88327b399bf8fd2aa8dd5