### PR TITLE
Feature: Integrate province location mapping

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverService.scala
@@ -2,43 +2,50 @@ package com.crib.bills.dom6maps
 package apps.services.mapeditor
 
 import model.ProvinceId
-import model.map.{MapHeight, MapState, MapWidth, WrapState}
+import model.map.{MapHeight, MapState, MapWidth, ProvinceLocation, WrapState}
 
 object WrapSeverService:
   def isTopBottom(
       a: ProvinceId,
       b: ProvinceId,
-      width: MapWidth,
+      index: Map[ProvinceId, ProvinceLocation],
       height: MapHeight
   ): Boolean =
-    val rowA = ((a.value - 1) / width.value) + 1
-    val rowB = ((b.value - 1) / width.value) + 1
-    val top = height.value
-    val bottom = 1
-    (rowA == top && rowB == bottom) || (rowA == bottom && rowB == top)
+    (index.get(a), index.get(b)) match
+      case (Some(locA), Some(locB)) =>
+        val top = height.value - 1
+        val bottom = 0
+        (locA.y.value == top && locB.y.value == bottom) || (locA.y.value == bottom && locB.y.value == top)
+      case _ => false
 
-  def isLeftRight(a: ProvinceId, b: ProvinceId, width: MapWidth): Boolean =
-    val rowA = ((a.value - 1) / width.value) + 1
-    val rowB = ((b.value - 1) / width.value) + 1
-    val colA = ((a.value - 1) % width.value) + 1
-    val colB = ((b.value - 1) % width.value) + 1
-    val left = 1
-    val right = width.value
-    rowA == rowB && ((colA == left && colB == right) || (colA == right && colB == left))
+  def isLeftRight(
+      a: ProvinceId,
+      b: ProvinceId,
+      index: Map[ProvinceId, ProvinceLocation],
+      width: MapWidth
+  ): Boolean =
+    (index.get(a), index.get(b)) match
+      case (Some(locA), Some(locB)) =>
+        val left = 0
+        val right = width.value - 1
+        locA.y.value == locB.y.value &&
+          ((locA.x.value == left && locB.x.value == right) ||
+            (locA.x.value == right && locB.x.value == left))
+      case _ => false
 
   def severVertically(state: MapState): MapState =
     state.size match
       case Some(sz) =>
-        val width = MapWidth(sz.value)
         val height = MapHeight(sz.value)
+        val index = state.provinceLocations.map(_.swap)
         val shouldSever = state.wrap == WrapState.FullWrap || state.wrap == WrapState.VerticalWrap
         val newAdj =
           if shouldSever then
-            state.adjacency.filterNot((a, b) => isTopBottom(a, b, width, height))
+            state.adjacency.filterNot((a, b) => isTopBottom(a, b, index, height))
           else state.adjacency
         val newBorders =
           if shouldSever then
-            state.borders.filterNot(b => isTopBottom(b.a, b.b, width, height))
+            state.borders.filterNot(b => isTopBottom(b.a, b.b, index, height))
           else state.borders
         val newWrap = state.wrap match
           case WrapState.FullWrap     => WrapState.HorizontalWrap
@@ -52,15 +59,15 @@ object WrapSeverService:
     state.size match
       case Some(sz) =>
         val width = MapWidth(sz.value)
-        val height = MapHeight(sz.value)
+        val index = state.provinceLocations.map(_.swap)
         val shouldSever = state.wrap == WrapState.FullWrap || state.wrap == WrapState.HorizontalWrap
         val newAdj =
           if shouldSever then
-            state.adjacency.filterNot((a, b) => isLeftRight(a, b, width))
+            state.adjacency.filterNot((a, b) => isLeftRight(a, b, index, width))
           else state.adjacency
         val newBorders =
           if shouldSever then
-            state.borders.filterNot(b => isLeftRight(b.a, b.b, width))
+            state.borders.filterNot(b => isLeftRight(b.a, b.b, index, width))
           else state.borders
         val newWrap = state.wrap match
           case WrapState.FullWrap       => WrapState.VerticalWrap

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/WrapConversionServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/WrapConversionServiceSpec.scala
@@ -32,7 +32,8 @@ object WrapConversionServiceSpec extends SimpleIOSuite:
       (state, w, h) <- load
       resEC <- service.convert[EC](state, WrapChoice.HWrap)
       res <- IO.fromEither(resEC)
-      hasTopBottom = res.adjacency.exists((a, b) => isTopBottom(a, b, w, h))
+      index = res.provinceLocations.map(_.swap)
+      hasTopBottom = res.adjacency.exists((a, b) => isTopBottom(a, b, index, h))
     yield expect.all(
       res.wrap == WrapState.HorizontalWrap,
       !hasTopBottom
@@ -45,7 +46,8 @@ object WrapConversionServiceSpec extends SimpleIOSuite:
       (state, w, h) <- load
       resEC <- service.convert[EC](state, WrapChoice.VWrap)
       res <- IO.fromEither(resEC)
-      hasLeftRight = res.adjacency.exists((a, b) => isLeftRight(a, b, w))
+      index = res.provinceLocations.map(_.swap)
+      hasLeftRight = res.adjacency.exists((a, b) => isLeftRight(a, b, index, w))
     yield expect.all(
       res.wrap == WrapState.VerticalWrap,
       !hasLeftRight
@@ -58,8 +60,9 @@ object WrapConversionServiceSpec extends SimpleIOSuite:
       (state, w, h) <- load
       resEC <- service.convert[EC](state, WrapChoice.NoWrap)
       res <- IO.fromEither(resEC)
-      hasTopBottom = res.adjacency.exists((a, b) => isTopBottom(a, b, w, h))
-      hasLeftRight = res.adjacency.exists((a, b) => isLeftRight(a, b, w))
+      index = res.provinceLocations.map(_.swap)
+      hasTopBottom = res.adjacency.exists((a, b) => isTopBottom(a, b, index, h))
+      hasLeftRight = res.adjacency.exists((a, b) => isLeftRight(a, b, index, w))
     yield expect.all(
       res.wrap == WrapState.NoWrap,
       !hasTopBottom,

--- a/documentation/engineering/architecture/map_state.md
+++ b/documentation/engineering/architecture/map_state.md
@@ -11,7 +11,9 @@
 - `allowedPlayers` and `startingPositions` – player nation and starting province pairs.
 - `terrains` – terrain masks for provinces.
 - `gates` – special province links.
+- `provinceLocations` – index mapping grid coordinates to `ProvinceId`.
 
-The companion object provides `fromDirectives` which folds a stream of `MapDirective` values to populate these fields.
+The companion object provides `fromDirectives` which folds a stream of `MapDirective` values to populate these fields and
+derives the location index via `ProvinceLocationService`.
 
 `MapDirectiveCodecs` supplies the inverse operation by encoding `MapState` and its components back into canonical `MapDirective` values.

--- a/documentation/engineering/architecture/map_state_model_migration.md
+++ b/documentation/engineering/architecture/map_state_model_migration.md
@@ -15,7 +15,7 @@ This document outlines how to evolve the map editing pipeline to use a compact `
    - Unknown lines preserved as `UnknownDirective`.
 2. **[MapState](map_state.md)** – authoritative facts derived from events:
    - Map dimensions.
-   - Vector of province locations.
+   - Location index mapping coordinates to province identifiers.
    - Adjacency graph.
    - Configuration flags to guide transformations.
    - Excludes heavy payloads such as image rows.

--- a/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
+++ b/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
@@ -22,7 +22,8 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       allowedPlayers = Vector(AllowedPlayer(Nation.Atlantis_Early)),
       startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
       terrains = Vector(Terrain(ProvinceId(5), 7)),
-      gates = Vector(Gate(ProvinceId(1), ProvinceId(2)))
+      gates = Vector(Gate(ProvinceId(1), ProvinceId(2))),
+      provinceLocations = Map.empty
     )
 
     val expected = Vector(

--- a/model/src/test/scala/model/map/MapStateSpec.scala
+++ b/model/src/test/scala/model/map/MapStateSpec.scala
@@ -37,7 +37,8 @@ object MapStateSpec extends SimpleIOSuite:
         allowedPlayers = Vector(AllowedPlayer(Nation.Atlantis_Early)),
         startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
         terrains = Vector(Terrain(ProvinceId(5), 7)),
-        gates = Vector(Gate(ProvinceId(1), ProvinceId(2)))
+        gates = Vector(Gate(ProvinceId(1), ProvinceId(2))),
+        provinceLocations = Map.empty
       )
       expect(state == expected)
     }


### PR DESCRIPTION
## Summary
- add province location index to MapState and derive it via ProvinceLocationService
- shift WrapSeverService to use coordinate-based wrap severing
- document location mapping in map state architecture notes

## Testing Done
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_689a5cd6e8d483279191958e034c455f