### PR TITLE
Feature: Province location index

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverService.scala
@@ -2,16 +2,16 @@ package com.crib.bills.dom6maps
 package apps.services.mapeditor
 
 import model.ProvinceId
-import model.map.{MapHeight, MapState, MapWidth, ProvinceLocation, WrapState}
+import model.map.{MapHeight, MapState, MapWidth, ProvinceLocation, ProvinceLocations, WrapState}
 
 object WrapSeverService:
   def isTopBottom(
       a: ProvinceId,
       b: ProvinceId,
-      index: Map[ProvinceId, ProvinceLocation],
+      index: ProvinceLocations,
       height: MapHeight
   ): Boolean =
-    (index.get(a), index.get(b)) match
+    (index.locationOf(a), index.locationOf(b)) match
       case (Some(locA), Some(locB)) =>
         val top = height.value - 1
         val bottom = 0
@@ -21,10 +21,10 @@ object WrapSeverService:
   def isLeftRight(
       a: ProvinceId,
       b: ProvinceId,
-      index: Map[ProvinceId, ProvinceLocation],
+      index: ProvinceLocations,
       width: MapWidth
   ): Boolean =
-    (index.get(a), index.get(b)) match
+    (index.locationOf(a), index.locationOf(b)) match
       case (Some(locA), Some(locB)) =>
         val left = 0
         val right = width.value - 1
@@ -37,15 +37,14 @@ object WrapSeverService:
     state.size match
       case Some(sz) =>
         val height = MapHeight(sz.value)
-        val index = state.provinceLocations.map(_.swap)
         val shouldSever = state.wrap == WrapState.FullWrap || state.wrap == WrapState.VerticalWrap
         val newAdj =
           if shouldSever then
-            state.adjacency.filterNot((a, b) => isTopBottom(a, b, index, height))
+            state.adjacency.filterNot((a, b) => isTopBottom(a, b, state.provinceLocations, height))
           else state.adjacency
         val newBorders =
           if shouldSever then
-            state.borders.filterNot(b => isTopBottom(b.a, b.b, index, height))
+            state.borders.filterNot(b => isTopBottom(b.a, b.b, state.provinceLocations, height))
           else state.borders
         val newWrap = state.wrap match
           case WrapState.FullWrap     => WrapState.HorizontalWrap
@@ -59,15 +58,14 @@ object WrapSeverService:
     state.size match
       case Some(sz) =>
         val width = MapWidth(sz.value)
-        val index = state.provinceLocations.map(_.swap)
         val shouldSever = state.wrap == WrapState.FullWrap || state.wrap == WrapState.HorizontalWrap
         val newAdj =
           if shouldSever then
-            state.adjacency.filterNot((a, b) => isLeftRight(a, b, index, width))
+            state.adjacency.filterNot((a, b) => isLeftRight(a, b, state.provinceLocations, width))
           else state.adjacency
         val newBorders =
           if shouldSever then
-            state.borders.filterNot(b => isLeftRight(b.a, b.b, index, width))
+            state.borders.filterNot(b => isLeftRight(b.a, b.b, state.provinceLocations, width))
           else state.borders
         val newWrap = state.wrap match
           case WrapState.FullWrap       => WrapState.VerticalWrap

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
@@ -103,7 +103,7 @@ dest="${destRoot.toString}"
       provinceSize = sizePixels.toProvinceSize
       h = provinceSize.height
       state <- MapState.fromDirectives(Stream.emits(directives).covary[IO])
-      index = state.provinceLocations.map(_.swap)
+      index = state.provinceLocations
       hasTopBottom = state.adjacency.exists((a, b) => isTopBottom(a, b, index, h))
     yield expect.all(
       destEntries.exists(_.fileName.toString == "newer"),

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/WrapConversionServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/WrapConversionServiceSpec.scala
@@ -32,7 +32,7 @@ object WrapConversionServiceSpec extends SimpleIOSuite:
       (state, w, h) <- load
       resEC <- service.convert[EC](state, WrapChoice.HWrap)
       res <- IO.fromEither(resEC)
-      index = res.provinceLocations.map(_.swap)
+      index = res.provinceLocations
       hasTopBottom = res.adjacency.exists((a, b) => isTopBottom(a, b, index, h))
     yield expect.all(
       res.wrap == WrapState.HorizontalWrap,
@@ -46,7 +46,7 @@ object WrapConversionServiceSpec extends SimpleIOSuite:
       (state, w, h) <- load
       resEC <- service.convert[EC](state, WrapChoice.VWrap)
       res <- IO.fromEither(resEC)
-      index = res.provinceLocations.map(_.swap)
+      index = res.provinceLocations
       hasLeftRight = res.adjacency.exists((a, b) => isLeftRight(a, b, index, w))
     yield expect.all(
       res.wrap == WrapState.VerticalWrap,
@@ -60,7 +60,7 @@ object WrapConversionServiceSpec extends SimpleIOSuite:
       (state, w, h) <- load
       resEC <- service.convert[EC](state, WrapChoice.NoWrap)
       res <- IO.fromEither(resEC)
-      index = res.provinceLocations.map(_.swap)
+      index = res.provinceLocations
       hasTopBottom = res.adjacency.exists((a, b) => isTopBottom(a, b, index, h))
       hasLeftRight = res.adjacency.exists((a, b) => isLeftRight(a, b, index, w))
     yield expect.all(

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverServiceSpec.scala
@@ -9,6 +9,7 @@ import model.map.{
   MapWidth,
   MapHeight,
   MapState,
+  ProvinceLocations,
   WrapState
 }
 import weaver.SimpleIOSuite
@@ -21,7 +22,7 @@ object WrapSeverServiceSpec extends SimpleIOSuite:
       size <- IO.fromOption(result.size)(new NoSuchElementException("#mapsize not found"))
       w = MapWidth(size.value)
       h = MapHeight(size.value)
-      index = result.provinceLocations.map(_.swap)
+      index = result.provinceLocations
       hasTopBottom = result.adjacency.exists((a, b) => WrapSeverService.isTopBottom(a, b, index, h))
       hasMiddle = result.adjacency.exists { case (a, b) => a.value == 6 && b.value == 7 }
     yield expect(result.wrap == WrapState.HorizontalWrap && !hasTopBottom && hasMiddle)
@@ -33,7 +34,7 @@ object WrapSeverServiceSpec extends SimpleIOSuite:
       result = WrapSeverService.severHorizontally(state)
       size <- IO.fromOption(result.size)(new NoSuchElementException("#mapsize not found"))
       w = MapWidth(size.value)
-      index = result.provinceLocations.map(_.swap)
+      index = result.provinceLocations
       hasLeftRight = result.adjacency.exists((a, b) => WrapSeverService.isLeftRight(a, b, index, w))
       hasMiddle = result.adjacency.exists { case (a, b) => a.value == 6 && b.value == 7 }
     yield expect(result.wrap == WrapState.VerticalWrap && !hasLeftRight && hasMiddle)
@@ -45,9 +46,11 @@ object WrapSeverServiceSpec extends SimpleIOSuite:
         !WrapSeverService.isTopBottom(
           ProvinceId(6),
           ProvinceId(1),
-          Map(
-            ProvinceId(6) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(1)),
-            ProvinceId(1) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(0))
+          ProvinceLocations.fromProvinceIdMap(
+            Map(
+              ProvinceId(6) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(1)),
+              ProvinceId(1) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(0))
+            )
           ),
           MapHeight(12)
         )
@@ -61,9 +64,11 @@ object WrapSeverServiceSpec extends SimpleIOSuite:
         !WrapSeverService.isLeftRight(
           ProvinceId(5),
           ProvinceId(6),
-          Map(
-            ProvinceId(5) -> model.map.ProvinceLocation(model.map.XCell(4), model.map.YCell(0)),
-            ProvinceId(6) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(1))
+          ProvinceLocations.fromProvinceIdMap(
+            Map(
+              ProvinceId(5) -> model.map.ProvinceLocation(model.map.XCell(4), model.map.YCell(0)),
+              ProvinceId(6) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(1))
+            )
           ),
           MapWidth(5)
         )

--- a/documentation/engineering/architecture/map_state.md
+++ b/documentation/engineering/architecture/map_state.md
@@ -11,9 +11,9 @@
 - `allowedPlayers` and `startingPositions` – player nation and starting province pairs.
 - `terrains` – terrain masks for provinces.
 - `gates` – special province links.
-- `provinceLocations` – index mapping grid coordinates to `ProvinceId`.
+- `provinceLocations` – bidirectional index between grid coordinates and `ProvinceId`.
 
 The companion object provides `fromDirectives` which folds a stream of `MapDirective` values to populate these fields and
-derives the location index via `ProvinceLocationService`.
+derives the location indexes via `ProvinceLocationService`.
 
 `MapDirectiveCodecs` supplies the inverse operation by encoding `MapState` and its components back into canonical `MapDirective` values.

--- a/model/src/main/scala/model/map/ProvinceLocations.scala
+++ b/model/src/main/scala/model/map/ProvinceLocations.scala
@@ -1,0 +1,23 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import model.ProvinceId
+
+final case class ProvinceLocations private (
+    indexByLocation: Map[ProvinceLocation, ProvinceId],
+    indexByProvinceId: Map[ProvinceId, ProvinceLocation]
+):
+  def provinceIdAt(location: ProvinceLocation): Option[ProvinceId] =
+    indexByLocation.get(location)
+
+  def locationOf(provinceId: ProvinceId): Option[ProvinceLocation] =
+    indexByProvinceId.get(provinceId)
+
+object ProvinceLocations:
+  val empty: ProvinceLocations = ProvinceLocations(Map.empty, Map.empty)
+
+  def fromProvinceIdMap(values: Map[ProvinceId, ProvinceLocation]): ProvinceLocations =
+    ProvinceLocations(values.map(_.swap), values)
+
+  def fromLocationMap(values: Map[ProvinceLocation, ProvinceId]): ProvinceLocations =
+    ProvinceLocations(values, values.map(_.swap))

--- a/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
+++ b/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
@@ -23,7 +23,7 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
       terrains = Vector(Terrain(ProvinceId(5), 7)),
       gates = Vector(Gate(ProvinceId(1), ProvinceId(2))),
-      provinceLocations = Map.empty
+      provinceLocations = ProvinceLocations.empty
     )
 
     val expected = Vector(

--- a/model/src/test/scala/model/map/MapStateSpec.scala
+++ b/model/src/test/scala/model/map/MapStateSpec.scala
@@ -38,7 +38,7 @@ object MapStateSpec extends SimpleIOSuite:
         startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
         terrains = Vector(Terrain(ProvinceId(5), 7)),
         gates = Vector(Gate(ProvinceId(1), ProvinceId(2))),
-        provinceLocations = Map.empty
+        provinceLocations = ProvinceLocations.empty
       )
       expect(state == expected)
     }


### PR DESCRIPTION
## Summary
- add `ProvinceLocations` to expose province lookups by id or map coordinate
- wire MapState and wrap sever logic to use the bidirectional index
- document the new index in the Map State architecture guide

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_b_689a67ff1a20832791b70e1a81d1d088