### PR TITLE
Feature: Province location wrap-around test

### DIFF
--- a/model/src/test/scala/model/map/ProvinceLocationWrapSpec.scala
+++ b/model/src/test/scala/model/map/ProvinceLocationWrapSpec.scala
@@ -1,0 +1,27 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import cats.effect.IO
+import fs2.Stream
+import model.ProvinceId
+import weaver.SimpleIOSuite
+
+object ProvinceLocationWrapSpec extends SimpleIOSuite:
+  private val size = MapSizePixels(MapWidthPixels(1024), MapHeightPixels(160))
+  private val id   = ProvinceId(1)
+  private val left = ProvincePixels(0, 0, 256, id)
+  private val right = ProvincePixels(768, 0, 256, id)
+  private def derive(dirs: List[MapDirective]) =
+    ProvinceLocationService.derive(Stream.emits(dirs).covary[IO])
+
+  test("wrap-around alters derived location"):
+    val base = List(size, left, right)
+    for
+      wrap   <- derive(WrapAround :: base)
+      nowrap <- derive(NoWrapAround :: base)
+    yield
+      val wrapLoc   = wrap(id)
+      val noWrapLoc = nowrap(id)
+      expect(wrapLoc != noWrapLoc) &&
+      expect.same(ProvinceLocation(XCell(3), YCell(0)), wrapLoc) &&
+      expect.same(ProvinceLocation(XCell(1), YCell(0)), noWrapLoc)


### PR DESCRIPTION
## Summary
- add ProvinceLocationWrapSpec to validate wrap-aware province coordinates

## Testing Done
- `sbt "project model" test`


------
https://chatgpt.com/codex/tasks/task_b_689a6de9ba8c8327ad3d3a2beff5bc9c