### PR TITLE
Feature: Map State migration progress

### DIFF
--- a/documentation/engineering/architecture/README.md
+++ b/documentation/engineering/architecture/README.md
@@ -24,3 +24,4 @@ Item 2, the effect patterns are mandatory reading if you plan on writing code. I
 15. [Map State](map_state.md)
 16. [Map State Model Migration Plan](map_state_model_migration.md)
 17. [Province Coordinate Derivation](province_coordinate_derivation.md)
+18. [Map State Model Migration Progress](map_state_model_migration_progress.md)

--- a/documentation/engineering/architecture/map_state_model_migration_progress.md
+++ b/documentation/engineering/architecture/map_state_model_migration_progress.md
@@ -1,0 +1,18 @@
+# Map State Model Migration Progress
+
+This living document tracks implementation against the [Map State Model Migration Plan](map_state_model_migration.md).
+
+## Status Summary
+- **MapState & ProvinceLocationService** – implemented (`model/src/main/scala/model/map/MapState.scala`, `model/src/main/scala/model/map/ProvinceLocationService.scala`).
+- **MapDirective coverage** – incomplete (`model/src/main/scala/model/map/MapDirective.scala` missing `#pb` and comment variants).
+- **Parser** – still drops unknown lines (`model/src/main/scala/model/map/MapFileParser.scala`).
+- **Pass 1 builder** – buffers full stream and loses pass-through directives (`model/src/main/scala/model/map/MapState.scala`).
+- **Pass 2 writer** – renders only state-owned directives; pass-through lost (`model/src/main/scala/model/map/MapDirectiveCodecs.scala`, `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala`).
+- **Services lacking MapDirective-stream integration** – `MapLayerLoader.scala`, `MapProcessingService.scala`, `GateDirectiveService.scala`, `ThronePlacementService.scala`, `SpawnPlacementService.scala`, `WrapConversionService.scala`, `WrapSeverService.scala`, `MapSizeValidator.scala`.
+- **Legacy province-id logic** – `ProvincePixels` directive still defined (`model/src/main/scala/model/map/MapDirective.scala`).
+
+## Blockers
+- Missing feature flag to toggle the two-pass pipeline.
+- Tests and adapters still consume direct `MapDirective` streams.
+- Parser does not surface unmapped `MapDirective` lines as defects.
+- Writer lacks pass-through re-emission.


### PR DESCRIPTION
## Summary
- rewrite migration plan to use `MapDirective` terminology and classify directives with authority, emission rules, and evidence
- document two-pass behavior and actionable step cards for completing the Map State pipeline
- update progress log to reflect MapDirective coverage gaps, remaining integrations, and blockers

## Testing
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_689f93616bc083279c4ffe7974eca60e