### PR TITLE
Feature: Map State migration progress

### DIFF
--- a/documentation/engineering/architecture/README.md
+++ b/documentation/engineering/architecture/README.md
@@ -24,3 +24,4 @@ Item 2, the effect patterns are mandatory reading if you plan on writing code. I
 15. [Map State](map_state.md)
 16. [Map State Model Migration Plan](map_state_model_migration.md)
 17. [Province Coordinate Derivation](province_coordinate_derivation.md)
+18. [Map State Model Migration Progress](map_state_model_migration_progress.md)

--- a/documentation/engineering/architecture/map_state_model_migration.md
+++ b/documentation/engineering/architecture/map_state_model_migration.md
@@ -1,51 +1,99 @@
 # Map State Model Migration Plan
 
-This document outlines how to evolve the map editing pipeline to use a compact `MapState` and directive events. The goal is to remove reliance on province-id based location data and instead pull coordinates and adjacency from a service.
+Migration to a directive stream `MapState` ensures that only documented `MapDirective` lines drive state while all other lines round‑trip verbatim. See [Migration Progress](map_state_model_migration_progress.md) for current status.
 
-## Impacted Services
-- `model.map.MapFileParser` – parse raw `.map` lines into `DirectiveEvent` instead of `MapDirective`.
-- `apps.services.mapeditor.MapLayerLoader` – build `MapState` from the event stream.
-- `apps.services.mapeditor.MapProcessingService` – operate on `MapState` and filtered event streams.
-- `apps.services.mapeditor.MapWriter` – emit directives from `MapState` and pass through remaining events.
-- Map modification pipes (`GateDirectiveService`, `ThronePlacementService`, `SpawnPlacementService`, `WrapConversionService`, `WrapSeverService`, `MapSizeValidator`) – adjust signatures to consume event streams or `MapState`.
+## Directive Inventory & Authority Map
+| Directive | Authority | Emission rule | Status (evidence) |
+| --- | --- | --- | --- |
+| `#mapsize` | State-owned | state-rendered | `model/src/main/scala/model/map/MapDirective.scala`, `model/src/main/scala/model/map/MapState.scala` |
+| `#dom2title`, `#description` | State-owned | state-rendered | `model/src/main/scala/model/map/MapDirective.scala` |
+| `#wraparound`, `#hwraparound`, `#vwraparound`, `#nowraparound` | State-owned | state-rendered | `model/src/main/scala/model/map/MapDirective.scala` |
+| `#allowedplayer`, `#specstart` | State-owned | state-rendered | `model/src/main/scala/model/map/MapDirective.scala` |
+| `#terrain`, `#gate`, `#neighbour`, `#neighbourspec` | State-owned | state-rendered | `model/src/main/scala/model/map/MapDirective.scala` |
+| `#province` | State-owned | state-rendered | `model/src/main/scala/model/map/MapDirective.scala` |
+| `#pb` | Pass-through + Derived-input | verbatim; source for derived province locations | `MapDirective.Pb` absent in `model/src/main/scala/model/map/MapDirective.scala` |
+| `#imagefile`, `#winterimagefile`, `#domversion`, `#nodeepcaves`, `#nodeepchoice`, `#mapnohide`, `#maptextcol`, `#mapdomcol`, `#landname` | Pass-through | verbatim | `model/src/main/scala/model/map/MapDirective.scala` |
+| comment lines (`--`) | Pass-through | verbatim | `MapDirective.Comment` absent in `model/src/main/scala/model/map/MapDirective.scala` |
+| Derived province locations (from `#pb` runs via `ProvinceLocationService`) | Derived-input | state-rendered | `model/src/main/scala/model/map/ProvinceLocationService.scala` |
 
-## Model Overview
-1. **Directive Events** – sealed hierarchy representing parsed directives:
-   - Known events: `MapSize`, `ProvinceAt`, `Adjacency`, `ImageRow`, `Comment`.
-   - Unknown lines preserved as `UnknownDirective`.
-2. **[MapState](map_state.md)** – authoritative facts derived from events:
-   - Map dimensions.
-   - Location index mapping coordinates to province identifiers.
-   - Adjacency graph.
-   - Configuration flags to guide transformations.
-   - Excludes heavy payloads such as image rows.
-3. **ProvinceLocationService** – capability that returns province coordinates and adjacency metadata. Replaces hard coded `ProvinceId` lookups.
+## Two-Pass Behavior
+Pass 1 consumes the full `MapDirective` stream to build `MapState`, retaining pass-through directives. Pass 2 re-emits pass-through directives verbatim and renders state-owned directives from `MapState` in canonical order; state-rendered output wins on conflicts. Verification relies on pass-through round-trips, ordered state sections, and feature-flagged end-to-end runs.
 
-## Staged Migration
-1. **Scaffolding**
-   - Introduce `DirectiveEvent`, `MapState`, and `ProvinceLocationService` in `model.map`.
-   - Provide JSON encoders/decoders following the existing renderer pattern.
-2. **Parser Upgrade**
-   - Extend `MapFileParser` to emit `DirectiveEvent`.
-   - Supply adapters converting legacy `MapDirective` streams to the new events.
-3. **State Builder**
-   - Implement a fold over the event stream that accumulates `MapState` and filters out directives represented in state.
-   - Replace province-id based coordinates with data from `ProvinceLocationService`.
-4. **Writer & Passthrough**
-   - Update `MapWriter` to render canonical directives from `MapState`.
-   - Merge with a "remaining directives" stream for comments, image rows, and unknown lines.
-5. **Service Refactor**
-   - Modify `MapLayerLoader`, `MapProcessingService`, and map modification pipes to consume `MapState` and event streams.
-   - Adjust tests in `apps` to use the new model.
-6. **Removal & Hardening**
-   - Deprecate `ProvincePixels` and related province-id coordinate logic.
-   - Run full compilation and service-level tests before removing legacy pathways.
+### Ordering & Merge Rules
+- **State-rendered families:** map metadata (`#mapsize`, `#dom2title`, `#description`), wrap settings (`#wraparound`, `#hwraparound`, `#vwraparound`, `#nowraparound`), player constraints (`#allowedplayer`, `#specstart`), and province blocks (`#province`, `#terrain`, `#gate`, `#neighbour`, `#neighbourspec`, `#landname`).
+- **Merge policy:** Pass 2 emits state-rendered families in the above order; preserved pass-through lines are interleaved at their original relative positions. When state-rendered directives conflict with existing lines, the state-rendered output wins.
 
-## Rollout Notes
-- Each stage should ship behind a feature flag to avoid disrupting current workflows.
-- Update examples such as `MapEditorWrapApp` once the pipeline stabilizes.
-- Document new service contracts and encode references in API docs.
+## Executable Step Cards
+1. **Scaffolding (Complete)**
+   *Purpose:* Establish minimal state model and province location derivation.
+   *Preconditions (evidence):* `model/src/main/scala/model/map/MapState.scala`, `model/src/main/scala/model/map/ProvinceLocationService.scala`.
+   *Actions:* none.
+   *Deliverables:* existing files.
+   *Verification:* `model/src/test/scala/model/map/MapStateSpec.scala`, `model/src/test/scala/model/map/ProvinceLocationServiceSpec.scala`.
+   *Status:* Complete.
 
-## References
-- [Map Editor Processing Pipeline](map_editor_pipeline.md)
-- [Map Modification Services](map_modification_services.md)
+2. **Complete `MapDirective` coverage (Pending)**
+   *Purpose:* Represent all documented directives and comments.
+   *Preconditions (evidence):* `model/src/main/scala/model/map/MapDirective.scala` lacks variants for `#pb` and comments.
+   *Actions:* add `MapDirective` variants for `#pb` and comment lines; update docs.
+   *Deliverables:* `MapDirective.scala`, inventory.
+   *Verification:* parser unit tests.
+   *Status:* Pending.
+
+3. **Parser emits all `MapDirective` variants and fails on unmapped lines (Pending)**
+   *Purpose:* Ensure Pass 1 sees every directive and surfaces defects.
+   *Preconditions (evidence):* `model/src/main/scala/model/map/MapFileParser.scala` drops unknown lines.
+   *Actions:* emit all `MapDirective` variants, capture comments, raise on unmapped lines.
+   *Deliverables:* `MapFileParser.scala`, parser tests.
+   *Verification:* round-trip tests with malformed input.
+   *Status:* Pending.
+
+4. **Pass 1 state builder retains pass-through directives (Pending)**
+   *Purpose:* Stream derivation of `MapState` with pass-through preservation.
+   *Preconditions (evidence):* `model/src/main/scala/model/map/MapState.scala` buffers full stream and loses pass-through directives.
+   *Actions:* fold over `MapDirective` stream producing `MapState` and residual pass-through stream.
+   *Deliverables:* updated `MapState.scala`.
+   *Verification:* unit tests comparing to existing `fromDirectives`.
+   *Status:* Pending.
+
+5. **Pass 2 writer merges outputs and pass-through lines (Pending)**
+   *Purpose:* Re-emit pass-through directives verbatim and render state-owned directives in order.
+   *Preconditions (evidence):* `model/src/main/scala/model/map/MapDirectiveCodecs.scala` and `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala` only render `MapState`.
+   *Actions:* render state-owned directives in canonical order, merge with preserved pass-through stream, append verbatim lines with ordering checks.
+   *Deliverables:* `MapDirectiveCodecs.scala`, `MapWriter.scala`.
+   *Verification:* golden file round-trip with ordering assertions.
+   *Status:* Pending.
+
+6. **Feature-flag integration in loaders and processors (Pending)**
+   *Purpose:* Adopt two-pass pipeline without disrupting existing flows.
+   *Preconditions (evidence):* `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapLayerLoader.scala` and `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapProcessingService.scala` load `MapState` directly without feature flag.
+   *Actions:* introduce feature flag; switch to two-pass pipeline when enabled.
+   *Deliverables:* service implementations, configuration.
+   *Verification:* feature flag tests.
+   *Status:* Pending.
+
+7. **Refactor map modification services (Pending)**
+   *Purpose:* Operate on `MapState` plus directive stream.
+   *Preconditions (evidence):* services such as `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/GateDirectiveService.scala` accept only `MapState`.
+   *Actions:* update service signatures and adapters.
+   *Deliverables:* service files and tests.
+   *Verification:* service-level tests.
+   *Status:* Pending.
+
+8. **Retire province-id location logic (Pending)**
+   *Purpose:* Remove reliance on `ProvincePixels` after new pipeline is proven.
+   *Preconditions (evidence):* `model/src/main/scala/model/map/MapDirective.scala` defines `ProvincePixels`.
+   *Actions:* drop `ProvincePixels` handling and old lookup paths.
+   *Deliverables:* directive models and docs.
+   *Verification:* compilation and end-to-end tests under flags.
+   *Status:* Pending.
+
+## Two-pass Proof Checklist
+- Diff original map with Pass 2 output to confirm ordering and verbatim pass-through.
+- Ensure `MapState` from Pass 1 matches `MapState.fromDirectives` for the same input.
+- Run end-to-end flow with the feature flag off and on to confirm dual-path behaviour.
+
+## Perf/Memory Acceptance
+- Centroid and grid derivation from `#pb` runs must stream the directive stream once and retain only `MapState` in memory.
+- Pass 1 and `ProvinceLocationService` will be exercised under constrained heap (`-Xmx64m`) in tests to assert constant-space behaviour.
+- Large-map golden tests confirm output equivalence without requiring full-file buffering.

--- a/documentation/engineering/architecture/map_state_model_migration_progress.md
+++ b/documentation/engineering/architecture/map_state_model_migration_progress.md
@@ -1,0 +1,18 @@
+# Map State Model Migration Progress
+
+This living document tracks implementation against the [Map State Model Migration Plan](map_state_model_migration.md).
+
+## Status Summary
+- **MapState & ProvinceLocationService** – implemented (`model/src/main/scala/model/map/MapState.scala`, `model/src/main/scala/model/map/ProvinceLocationService.scala`).
+- **MapDirective coverage** – incomplete (`MapDirective.Pb` and `MapDirective.Comment` absent in `model/src/main/scala/model/map/MapDirective.scala`).
+- **Parser** – still drops unknown lines (`model/src/main/scala/model/map/MapFileParser.scala`).
+- **Pass 1 builder** – buffers full stream and loses pass-through directives (`model/src/main/scala/model/map/MapState.scala`).
+- **Pass 2 writer** – renders only state-owned directives; pass-through lost (`model/src/main/scala/model/map/MapDirectiveCodecs.scala`, `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala`).
+- **Services lacking MapDirective-stream integration** – `MapLayerLoader.scala`, `MapProcessingService.scala`, `GateDirectiveService.scala`, `ThronePlacementService.scala`, `SpawnPlacementService.scala`, `WrapConversionService.scala`, `WrapSeverService.scala`, `MapSizeValidator.scala`.
+- **Legacy province-id logic** – `ProvincePixels` directive still defined (`model/src/main/scala/model/map/MapDirective.scala`).
+
+## Blockers
+- Missing feature flag to toggle the two-pass pipeline.
+- Tests and adapters still consume direct `MapDirective` streams.
+- Parser does not surface unmapped `MapDirective` lines as defects.
+- Writer lacks pass-through re-emission.


### PR DESCRIPTION
## Summary
- clarify directive stream migration plan with explicit ordering/merge rules and perf/memory expectations
- mark #pb and comment line coverage as absent MapDirective variants with file-path evidence

## Testing
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_689f93616bc083279c4ffe7974eca60e