### PR TITLE
Feature: Pass-through writer merge

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala
@@ -6,30 +6,38 @@ import cats.syntax.all.*
 import fs2.Stream
 import fs2.io.file.{Files, Path}
 import cats.effect.Async
-import model.map.{MapDirective, MapState, Renderer}
+import model.map.{MapDirective, MapState, Renderer, MapDirectiveCodecs}
 import model.map.Renderer.*
-import model.map.MapDirectiveCodecs.Encoder
-import model.map.MapDirectiveCodecs.Encoder.given
 import java.nio.charset.StandardCharsets
 
 trait MapWriter[Sequencer[_]]:
   def write[ErrorChannel[_]](
       state: MapState,
+      passThrough: Vector[MapDirective],
       output: Path
   )(using files: Files[Sequencer],
         errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
   ): Sequencer[ErrorChannel[Unit]]
+
+  def write[ErrorChannel[_]](
+      state: MapState,
+      output: Path
+  )(using files: Files[Sequencer],
+        errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
+  ): Sequencer[ErrorChannel[Unit]] =
+    write(state, Vector.empty, output)
 
 class MapWriterImpl[Sequencer[_]: Async: Files] extends MapWriter[Sequencer]:
   protected val sequencer = summon[Async[Sequencer]]
 
   override def write[ErrorChannel[_]](
       state: MapState,
+      passThrough: Vector[MapDirective],
       output: Path
   )(using files: Files[Sequencer],
         errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
   ): Sequencer[ErrorChannel[Unit]] =
-    val directives = Encoder[MapState].encode(state)
+    val directives = MapDirectiveCodecs.merge(state, passThrough)
     val bytes = directives.map(_.render).mkString("\n").getBytes(StandardCharsets.UTF_8)
     for
       _ <- sequencer.delay(println(s"Writing map to $output"))

--- a/documentation/engineering/architecture/map_state_model_migration_progress.md
+++ b/documentation/engineering/architecture/map_state_model_migration_progress.md
@@ -8,11 +8,10 @@ This living document tracks implementation against the [Map State Model Migratio
 - **MapDirective coverage** – complete (`MapDirective.Pb` and `MapDirective.Comment` defined in `model/src/main/scala/model/map/MapDirective.scala`).
 - **Parser** – emits all directives and fails on unmapped lines (`model/src/main/scala/model/map/MapFileParser.scala`).
 - **Pass 1 builder** – retains pass-through directives (`MapState.fromDirectivesWithPassThrough` in `model/src/main/scala/model/map/MapState.scala`) but still buffers the full stream.
-- **Pass 2 writer** – renders only state-owned directives; pass-through lost (`model/src/main/scala/model/map/MapDirectiveCodecs.scala`, `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala`).
+- **Pass 2 writer** – merges state-owned output with verbatim pass-through directives (`MapDirectiveCodecs.merge` in `model/src/main/scala/model/map/MapDirectiveCodecs.scala`, `MapWriter.write` in `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala`).
 - **Services lacking MapDirective-stream integration** – `MapLayerLoader.scala`, `MapProcessingService.scala`, `GateDirectiveService.scala`, `ThronePlacementService.scala`, `SpawnPlacementService.scala`, `WrapConversionService.scala`, `WrapSeverService.scala`, `MapSizeValidator.scala`.
 - **Legacy province-id logic** – `ProvincePixels` directive still defined (`model/src/main/scala/model/map/MapDirective.scala`).
 
 ## Blockers
 - Missing feature flag to toggle the two-pass pipeline.
 - Tests and adapters still consume direct `MapDirective` streams.
-- Writer lacks pass-through re-emission.


### PR DESCRIPTION
Implemented pass-through directive merging in MapWriter.

### Testing Done
- `sbt "project apps" "testOnly com.crib.bills.dom6maps.apps.services.mapeditor.MapWriterRoundTripSpec"`

Adds merge function to MapDirectiveCodecs and extends MapWriter to accept preserved pass-through directives, enabling round-trip re-emission. Updated migration progress documentation.

------
https://chatgpt.com/codex/tasks/task_b_68a0052abf9483278857795bb94d1711