### PR TITLE
Feature: Mark pass 2 writer card complete

### DIFF
--- a/documentation/engineering/architecture/map_state_model_migration.md
+++ b/documentation/engineering/architecture/map_state_model_migration.md
@@ -56,13 +56,13 @@ Pass 1 consumes the full `MapDirective` stream to build `MapState`, retaining pa
    *Verification:* unit tests comparing to existing `fromDirectives`.
    *Status:* Complete.
 
-5. **Pass 2 writer merges outputs and pass-through lines (Pending)**
+5. **Pass 2 writer merges outputs and pass-through lines (Complete)**
    *Purpose:* Re-emit pass-through directives verbatim and render state-owned directives in order.
    *Preconditions (evidence):* `model/src/main/scala/model/map/MapDirectiveCodecs.scala` and `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala` only render `MapState`.
    *Actions:* render state-owned directives in canonical order, merge with preserved pass-through stream, append verbatim lines with ordering checks.
    *Deliverables:* `MapDirectiveCodecs.scala`, `MapWriter.scala`.
    *Verification:* golden file round-trip with ordering assertions.
-   *Status:* Pending.
+   *Status:* Complete.
 
 6. **Refactor map modification services (Pending)**
    *Purpose:* Operate on `MapState` plus directive stream.

--- a/documentation/engineering/architecture/map_state_model_migration_progress.md
+++ b/documentation/engineering/architecture/map_state_model_migration_progress.md
@@ -8,7 +8,7 @@ This living document tracks implementation against the [Map State Model Migratio
 - **MapDirective coverage** – complete (`MapDirective.Pb` and `MapDirective.Comment` defined in `model/src/main/scala/model/map/MapDirective.scala`).
 - **Parser** – emits all directives and fails on unmapped lines (`model/src/main/scala/model/map/MapFileParser.scala`).
 - **Pass 1 builder** – retains pass-through directives (`MapState.fromDirectivesWithPassThrough` in `model/src/main/scala/model/map/MapState.scala`) but still buffers the full stream.
-- **Pass 2 writer** – merges state-owned output with verbatim pass-through directives (`MapDirectiveCodecs.merge` in `model/src/main/scala/model/map/MapDirectiveCodecs.scala`, `MapWriter.write` in `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala`).
+- **Pass 2 writer** – merges state-owned output with verbatim pass-through directives (`MapDirectiveCodecs.merge` in `model/src/main/scala/model/map/MapDirectiveCodecs.scala`, `MapWriter.write` in `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala`, `MapWriterRoundTripSpec` in `apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriterRoundTripSpec.scala`).
 - **Services lacking MapDirective-stream integration** – `MapLayerLoader.scala`, `MapProcessingService.scala`, `GateDirectiveService.scala`, `ThronePlacementService.scala`, `SpawnPlacementService.scala`, `WrapConversionService.scala`, `WrapSeverService.scala`, `MapSizeValidator.scala`.
 - **Legacy province-id logic** – `ProvincePixels` directive still defined (`model/src/main/scala/model/map/MapDirective.scala`).
 


### PR DESCRIPTION
## Summary
- mark Pass 2 writer card complete in migration plan
- note MapWriterRoundTripSpec evidence in migration progress doc

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_b_68a21f00583c8327b6591d9f5678e0d7