### PR TITLE
Feature: Retire province-id location logic

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
@@ -84,14 +84,6 @@ object Arbitraries:
       p <- summon[Arbitrary[ProvinceId]].arbitrary
     yield Pb(x, y, l, p))
 
-  given Arbitrary[ProvincePixels] =
-    Arbitrary(for
-      x <- Gen.choose(0, 5000)
-      y <- Gen.choose(0, 5000)
-      l <- Gen.choose(1, 5000)
-      p <- summon[Arbitrary[ProvinceId]].arbitrary
-    yield ProvincePixels(x, y, l, p))
-
   given Arbitrary[Terrain] =
     Arbitrary(for
       p <- summon[Arbitrary[ProvinceId]].arbitrary

--- a/documentation/engineering/architecture/map_state_model_migration.md
+++ b/documentation/engineering/architecture/map_state_model_migration.md
@@ -72,13 +72,13 @@ Pass 1 consumes the full `MapDirective` stream to build `MapState`, retaining pa
    *Verification:* service-level tests.
    *Status:* Complete.
 
-7. **Retire province-id location logic (Pending)**
+7. **Retire province-id location logic (Complete)**
    *Purpose:* Remove reliance on `ProvincePixels` after new pipeline is proven.
-   *Preconditions (evidence):* `model/src/main/scala/model/map/MapDirective.scala` defines `ProvincePixels`.
+   *Preconditions (evidence):* `ProvincePixels` directive removed from `model/src/main/scala/model/map/MapDirective.scala`.
    *Actions:* drop `ProvincePixels` handling and old lookup paths.
    *Deliverables:* directive models and docs.
    *Verification:* compilation and end-to-end tests.
-   *Status:* Pending.
+   *Status:* Complete.
 
 ## Two-pass Proof Checklist
 - Diff original map with Pass 2 output to confirm ordering and verbatim pass-through.

--- a/documentation/engineering/architecture/map_state_model_migration_progress.md
+++ b/documentation/engineering/architecture/map_state_model_migration_progress.md
@@ -10,7 +10,7 @@ This living document tracks implementation against the [Map State Model Migratio
 - **Pass 1 builder** – retains pass-through directives (`MapState.fromDirectivesWithPassThrough` in `model/src/main/scala/model/map/MapState.scala`) but still buffers the full stream.
 - **Pass 2 writer** – merges state-owned output with verbatim pass-through directives (`MapDirectiveCodecs.merge` in `model/src/main/scala/model/map/MapDirectiveCodecs.scala`, `MapWriter.write` in `apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriter.scala`, `MapWriterRoundTripSpec` in `apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapWriterRoundTripSpec.scala`).
 - **Services lacking MapDirective-stream integration** – `GateDirectiveService.scala`, `ThronePlacementService.scala`, `SpawnPlacementService.scala`, `WrapConversionService.scala`, `WrapSeverService.scala`, `MapSizeValidator.scala`.
-- **Legacy province-id logic** – `ProvincePixels` directive still defined (`model/src/main/scala/model/map/MapDirective.scala`).
+- **Legacy province-id logic** – retired; `ProvincePixels` directive removed (`model/src/main/scala/model/map/MapDirective.scala`).
 
 ## Blockers
 - Tests and adapters still consume direct `MapDirective` streams.

--- a/model/src/main/scala/model/map/MapDirective.scala
+++ b/model/src/main/scala/model/map/MapDirective.scala
@@ -39,7 +39,6 @@ import com.crib.bills.dom6maps.model.{Nation, ProvinceId, BorderFlag}
 final case class AllowedPlayer(nation: Nation) extends MapDirective
 final case class SpecStart(nation: Nation, province: ProvinceId) extends MapDirective
 final case class Pb(x: Int, y: Int, length: Int, province: ProvinceId) extends MapDirective
-final case class ProvincePixels(x: Int, y: Int, length: Int, province: ProvinceId) extends MapDirective
 final case class Terrain(province: ProvinceId, mask: Int) extends MapDirective
 final case class LandName(province: ProvinceId, name: String) extends MapDirective
 final case class Gate(a: ProvinceId, b: ProvinceId) extends MapDirective

--- a/model/src/main/scala/model/map/ProvinceLocationService.scala
+++ b/model/src/main/scala/model/map/ProvinceLocationService.scala
@@ -50,8 +50,7 @@ object ProvinceLocationService:
       case HWrapAround         => state.copy(wrapH = true)
       case VWrapAround         => state.copy(wrapV = true)
       case NoWrapAround        => state.copy(wrapH = false, wrapV = false)
-      case ProvincePixels(x, y, len, p) => accumulatePixels(state, x, y, len, p)
-      case Pb(x, y, len, p)            => accumulatePixels(state, x, y, len, p)
+      case Pb(x, y, len, p) => accumulatePixels(state, x, y, len, p)
       case _ => state
 
   private def updateAcc(acc: Acc, x: Int, y: Int, len: Int, state: State): Acc =

--- a/model/src/main/scala/model/map/Renderer.scala
+++ b/model/src/main/scala/model/map/Renderer.scala
@@ -33,7 +33,6 @@ object Renderer:
         case AllowedPlayer(n)      => s"#allowedplayer ${n.id}"
         case SpecStart(n,p)        => s"#specstart ${n.id} ${p.value}"
         case Pb(x,y,l,p)           => s"#pb $x $y $l ${p.value}"
-        case ProvincePixels(x,y,l,p) => s"#pb $x $y $l ${p.value}"
         case Terrain(p,m)          => s"#terrain ${p.value} $m"
         case LandName(p,n)         => s"#landname ${p.value} \"$n\""
         case Gate(a,b)             => s"#gate ${a.value} ${b.value}"

--- a/model/src/test/scala/model/map/ProvinceLocationWrapSpec.scala
+++ b/model/src/test/scala/model/map/ProvinceLocationWrapSpec.scala
@@ -9,8 +9,8 @@ import weaver.SimpleIOSuite
 object ProvinceLocationWrapSpec extends SimpleIOSuite:
   private val size = MapSizePixels(MapWidthPixels(1024), MapHeightPixels(160))
   private val id   = ProvinceId(1)
-  private val left = ProvincePixels(0, 0, 256, id)
-  private val right = ProvincePixels(768, 0, 256, id)
+  private val left  = Pb(0, 0, 256, id)
+  private val right = Pb(768, 0, 256, id)
   private def derive(dirs: List[MapDirective]) =
     ProvinceLocationService.derive(Stream.emits(dirs).covary[IO])
 


### PR DESCRIPTION
## Summary
- remove legacy `ProvincePixels` directive from map directive model
- update location derivation and rendering to handle only `Pb`
- document retirement of province-id lookup

## Testing
- `sbt compile`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68a2308c5f548327ba5356445273ea8d