### PR TITLE
[Fix]: Document cave layer default copy

### DIFF
--- a/documentation/engineering/wrap_selection_service.md
+++ b/documentation/engineering/wrap_selection_service.md
@@ -3,6 +3,10 @@
 This document describes the services that allow a user to choose how map wrap
 settings are converted.
 
+Prior to this fix, the cave layer was only processed when a specific cave wrap
+was selected. [`MapWrapWorkflow`](../../apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/MapWrapWorkflow.scala)
+now copies the surface selection to the cave layer by default.
+
 ## Components
 - **WrapChoiceService** – displays a Swing dialog with radio buttons for
   `hwrap`, `vwrap`, `no-wrap`, or `ground-surface duel`. Selecting the duel


### PR DESCRIPTION
## Summary
- note cave layer now defaults to copying the surface wrap when no cave-specific wrap is chosen

## Testing
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_68a4bc9b25d083279af6551b2bc290e8