### PR TITLE
[Fix]: Wrap state matches conversion target

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapConversionService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapConversionService.scala
@@ -4,7 +4,7 @@ package apps.services.mapeditor
 import cats.{MonadError, Traverse}
 import cats.syntax.all.*
 import cats.effect.Sync
-import model.map.MapState
+import model.map.{MapState, WrapState}
 
 trait WrapConversionService[Sequencer[_]]:
   def convert[ErrorChannel[_]](
@@ -24,9 +24,13 @@ class WrapConversionServiceImpl[Sequencer[_]: Sync] extends WrapConversionServic
       errorChannel: MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]
   ): Sequencer[ErrorChannel[MapState]] =
     val result = target match
-      case WrapChoice.HWrap => WrapSeverService.severVertically(state)
-      case WrapChoice.VWrap => WrapSeverService.severHorizontally(state)
+      case WrapChoice.HWrap =>
+        WrapSeverService.severVertically(state).copy(wrap = WrapState.HorizontalWrap)
+      case WrapChoice.VWrap =>
+        WrapSeverService.severHorizontally(state).copy(wrap = WrapState.VerticalWrap)
       case WrapChoice.NoWrap =>
-        WrapSeverService.severHorizontally(WrapSeverService.severVertically(state))
+        WrapSeverService
+          .severHorizontally(WrapSeverService.severVertically(state))
+          .copy(wrap = WrapState.NoWrap)
       case WrapChoice.GroundSurfaceDuel => state
     sequencer.delay(println(s"Converting map to $target")).as(errorChannel.pure(result))


### PR DESCRIPTION
## Summary
- force converted maps to record the target wrap state
- verify wrap directives when converting from full wrap or no wrap

## Testing Done
- `sbt compile`
- `sbt "project apps" test` *(fails: MapRendererSpec render round trip)*
- `sbt "project apps" "testOnly com.crib.bills.dom6maps.apps.services.mapeditor.WrapConversionServiceSpec"`


------
https://chatgpt.com/codex/tasks/task_b_68a4e21ccb9c832797ce318116f7477b