### PR TITLE
Feature: Document province feature directives

### DIFF
--- a/documentation/domain/dominions/README.md
+++ b/documentation/domain/dominions/README.md
@@ -4,3 +4,4 @@ This folder collects reference materials and domain notes for modeling Dominions
 
 - [Manual Breakdown](manual/Dominions_Manual.md)
 - [Model Progress](domain_model.md)
+- [Province Feature Commands](province_features.md)

--- a/documentation/domain/dominions/province_features.md
+++ b/documentation/domain/dominions/province_features.md
@@ -1,0 +1,31 @@
+# Province Feature Commands
+
+This page records how province level features are specified in a Dominions map file and outlines the planned support for them in the codebase.
+
+## Syntax
+
+Province features are assigned by pairing a province selection with a feature identifier:
+
+```text
+#setland <province identifier>
+#feature <feature identifier>
+```
+
+`#setland` selects the province to modify without removing its existing units. `#feature` then adds a feature such as a throne or unique site to that province. For example, `#setland 120` followed by `#feature 1358` adds the *Throne of Winter* to province 120.
+
+## Context
+
+The current map model captures terrain, adjacency, and special links but lacks a way to store feature overrides. Without this, user supplied features cannot be represented or written back to a map file. Feature directives also do not round-trip through the parser and renderer, leaving `#setland` and `#feature` lines as pass-through text.
+
+## Implementation Plan
+
+- Introduce `FeatureId` and `ProvinceFeature` models and store them in `MapState`.
+- Extend `MapDirective` with `SetLand` and `Feature` cases; teach the parser and renderer to read and write these directives.
+- Add encoding logic that emits a `#setland` followed by a `#feature` for each `ProvinceFeature` in `MapState`.
+- Provide a `ProvinceFeatureService` that replaces the `features` collection in `MapState` with supplied overrides.
+- Test round-trip parsing and service behaviour to ensure feature directives are preserved.
+
+## Related Pages
+
+- [Domain Model Progress](domain_model.md)
+- [Manual Breakdown](manual/Dominions_Manual.md)


### PR DESCRIPTION
## Summary
- document `#setland` and `#feature` province feature directives
- index the new guidance in Dominions domain docs

## Testing
- `sbt compile`


------
https://chatgpt.com/codex/tasks/task_b_68abcbcf77f88327af7a1cebbfb7e8cc