### PR TITLE
Feature: Track province features in map state

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
@@ -99,6 +99,15 @@ object Arbitraries:
       n <- Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString)
     yield LandName(p, n))
 
+  given Arbitrary[FeatureId] =
+    Arbitrary(Gen.choose(0, 1000).map(FeatureId.apply))
+
+  given Arbitrary[ProvinceFeature] =
+    Arbitrary(for
+      p <- summon[Arbitrary[ProvinceId]].arbitrary
+      f <- summon[Arbitrary[FeatureId]].arbitrary
+    yield ProvinceFeature(p, f))
+
   given Arbitrary[Gate] =
     Arbitrary(for
       a <- summon[Arbitrary[ProvinceId]].arbitrary
@@ -150,6 +159,7 @@ object Arbitraries:
       summon[Arbitrary[Pb]].arbitrary,
       summon[Arbitrary[Terrain]].arbitrary,
       summon[Arbitrary[LandName]].arbitrary,
+      summon[Arbitrary[ProvinceFeature]].arbitrary,
       summon[Arbitrary[Gate]].arbitrary,
       summon[Arbitrary[Neighbour]].arbitrary,
       summon[Arbitrary[NeighbourSpec]].arbitrary,

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
@@ -36,6 +36,7 @@ object MapRendererSpec extends SimpleIOSuite with Checkers:
     val e7 = expect(LandName(ProvinceId(1), "name").render == "#landname 1 \"name\"")
     val e8 = expect(Gate(ProvinceId(1), ProvinceId(2)).render == "#gate 1 2")
     val e9 = expect(Pb(1, 2, 3, ProvinceId(4)).render == "#pb 1 2 3 4")
-    val e10 = expect(Comment("note").render == "--note")
-    IO.pure(e1 and e2 and e3 and e4 and e5 and e6 and e7 and e8 and e9 and e10)
+    val e10 = expect(ProvinceFeature(ProvinceId(1), FeatureId(2)).render == "#feature 1 2")
+    val e11 = expect(Comment("note").render == "--note")
+    IO.pure(e1 and e2 and e3 and e4 and e5 and e6 and e7 and e8 and e9 and e10 and e11)
   }

--- a/model/src/main/scala/model/map/MapDirective.scala
+++ b/model/src/main/scala/model/map/MapDirective.scala
@@ -42,6 +42,8 @@ final case class SpecStart(nation: Nation, province: ProvinceId) extends MapDire
 final case class Pb(x: Int, y: Int, length: Int, province: ProvinceId) extends MapDirective
 final case class Terrain(province: ProvinceId, mask: Int) extends MapDirective
 final case class LandName(province: ProvinceId, name: String) extends MapDirective
+final case class FeatureId(value: Int) extends AnyVal
+final case class ProvinceFeature(province: ProvinceId, id: FeatureId) extends MapDirective
 final case class Gate(a: ProvinceId, b: ProvinceId) extends MapDirective
 final case class Neighbour(a: ProvinceId, b: ProvinceId) extends MapDirective
 final case class NeighbourSpec(a: ProvinceId, b: ProvinceId, border: BorderFlag) extends MapDirective

--- a/model/src/main/scala/model/map/MapDirectiveCodecs.scala
+++ b/model/src/main/scala/model/map/MapDirectiveCodecs.scala
@@ -54,6 +54,10 @@ object MapDirectiveCodecs:
     def encode(value: Terrain): Vector[MapDirective] =
       Vector(value)
 
+  given Encoder[ProvinceFeature] with
+    def encode(value: ProvinceFeature): Vector[MapDirective] =
+      Vector(value)
+
   given Encoder[Gate] with
     def encode(value: Gate): Vector[MapDirective] =
       Vector(value)
@@ -75,13 +79,14 @@ object MapDirectiveCodecs:
       val players = value.allowedPlayers.flatMap(Encoder[AllowedPlayer].encode)
       val starts = value.startingPositions.flatMap(Encoder[SpecStart].encode)
       val terrains = value.terrains.flatMap(Encoder[Terrain].encode)
+      val features = value.features.flatMap(Encoder[ProvinceFeature].encode)
       val gates = value.gates.flatMap(Encoder[Gate].encode)
       val borderPairs = value.borders.map(b => (b.a, b.b)).toSet
       val adjacency = value.adjacency
         .filterNot(borderPairs.contains)
         .flatMap(Encoder[(ProvinceId, ProvinceId)].encode)
       val borders = value.borders.flatMap(Encoder[Border].encode)
-      size ++ wrap ++ title ++ description ++ players ++ starts ++ terrains ++ gates ++ adjacency ++ borders
+      size ++ wrap ++ title ++ description ++ players ++ starts ++ terrains ++ features ++ gates ++ adjacency ++ borders
 
   private def isPassThrough(directive: MapDirective): Boolean =
     directive match
@@ -89,7 +94,7 @@ object MapDirectiveCodecs:
       case Dom2Title(_)                                                => false
       case Description(_)                                              => false
       case WrapAround | HWrapAround | VWrapAround | NoWrapAround       => false
-      case _: AllowedPlayer | _: SpecStart | _: Terrain | _: Gate      => false
+      case _: AllowedPlayer | _: SpecStart | _: Terrain | _: ProvinceFeature | _: Gate      => false
       case Neighbour(_, _) | NeighbourSpec(_, _, _)                    => false
       case _                                                           => true
 

--- a/model/src/main/scala/model/map/MapFileParser.scala
+++ b/model/src/main/scala/model/map/MapFileParser.scala
@@ -118,6 +118,11 @@ object MapFileParser:
       Some(LandName(ProvinceId(p), n))
     }
 
+  private def featureP[$: P]: P[Option[MapDirective]] =
+    P("#feature" ~ ws ~ int ~ ws ~ int).map { case (p, f) =>
+      Some(ProvinceFeature(ProvinceId(p), FeatureId(f)))
+    }
+
   private def gateP[$: P]: P[Option[MapDirective]] =
     P("#gate" ~ ws ~ int ~ ws ~ int).map { case (a, b) =>
       Some(Gate(ProvinceId(a), ProvinceId(b)))
@@ -161,6 +166,7 @@ object MapFileParser:
       pbP |
       terrainP |
       landnameP |
+      featureP |
       gateP |
       neighbourP |
       neighbourspecP |

--- a/model/src/main/scala/model/map/MapState.scala
+++ b/model/src/main/scala/model/map/MapState.scala
@@ -24,6 +24,7 @@ final case class MapState(
     allowedPlayers: Vector[AllowedPlayer],
     startingPositions: Vector[SpecStart],
     terrains: Vector[Terrain],
+    features: Vector[ProvinceFeature],
     gates: Vector[Gate],
     provinceLocations: ProvinceLocations
 )
@@ -36,6 +37,7 @@ object MapState:
     WrapState.NoWrap,
     None,
     None,
+    Vector.empty,
     Vector.empty,
     Vector.empty,
     Vector.empty,
@@ -89,6 +91,8 @@ object MapState:
         state.copy(startingPositions = state.startingPositions :+ ss)
       case t: Terrain =>
         state.copy(terrains = state.terrains :+ t)
+      case pf: ProvinceFeature =>
+        state.copy(features = state.features :+ pf)
       case g: Gate =>
         state.copy(gates = state.gates :+ g)
       case Neighbour(a, b) =>
@@ -107,6 +111,6 @@ object MapState:
       case Dom2Title(_)        => false
       case Description(_)      => false
       case WrapAround | HWrapAround | VWrapAround | NoWrapAround => false
-      case _: AllowedPlayer | _: SpecStart | _: Terrain | _: Gate => false
+      case _: AllowedPlayer | _: SpecStart | _: Terrain | _: ProvinceFeature | _: Gate => false
       case Neighbour(_, _) | NeighbourSpec(_, _, _)              => false
       case _                                                     => true

--- a/model/src/main/scala/model/map/Renderer.scala
+++ b/model/src/main/scala/model/map/Renderer.scala
@@ -36,6 +36,7 @@ object Renderer:
         case Pb(x,y,l,p)           => s"#pb $x $y $l ${p.value}"
         case Terrain(p,m)          => s"#terrain ${p.value} $m"
         case LandName(p,n)         => s"#landname ${p.value} \"$n\""
+        case ProvinceFeature(p,f)  => s"#feature ${p.value} ${f.value}"
         case Gate(a,b)             => s"#gate ${a.value} ${b.value}"
         case Neighbour(a,b)        => s"#neighbour ${a.value} ${b.value}"
         case NeighbourSpec(a,b,f)  => s"#neighbourspec ${a.value} ${b.value} ${f.mask}"

--- a/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
+++ b/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
@@ -22,6 +22,7 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       allowedPlayers = Vector(AllowedPlayer(Nation.Atlantis_Early)),
       startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
       terrains = Vector(Terrain(ProvinceId(5), 7)),
+      features = Vector(ProvinceFeature(ProvinceId(5), FeatureId(9))),
       gates = Vector(Gate(ProvinceId(1), ProvinceId(2))),
       provinceLocations = ProvinceLocations.empty
     )
@@ -34,6 +35,7 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       AllowedPlayer(Nation.Atlantis_Early),
       SpecStart(Nation.Atlantis_Early, ProvinceId(42)),
       Terrain(ProvinceId(5), 7),
+      ProvinceFeature(ProvinceId(5), FeatureId(9)),
       Gate(ProvinceId(1), ProvinceId(2)),
       Neighbour(ProvinceId(3), ProvinceId(4)),
       NeighbourSpec(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)

--- a/model/src/test/scala/model/map/MapStateSpec.scala
+++ b/model/src/test/scala/model/map/MapStateSpec.scala
@@ -19,6 +19,7 @@ object MapStateSpec extends SimpleIOSuite:
     SpecStart(Nation.Atlantis_Early, ProvinceId(42)),
     Terrain(ProvinceId(5), 7),
     LandName(ProvinceId(5), "LN"),
+    ProvinceFeature(ProvinceId(5), FeatureId(9)),
     Gate(ProvinceId(1), ProvinceId(2)),
     Neighbour(ProvinceId(3), ProvinceId(4)),
     NeighbourSpec(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)
@@ -46,6 +47,7 @@ object MapStateSpec extends SimpleIOSuite:
         allowedPlayers = Vector(AllowedPlayer(Nation.Atlantis_Early)),
         startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
         terrains = Vector(Terrain(ProvinceId(5), 7)),
+        features = Vector(ProvinceFeature(ProvinceId(5), FeatureId(9))),
         gates = Vector(Gate(ProvinceId(1), ProvinceId(2))),
         provinceLocations = ProvinceLocations.fromProvinceIdMap(
           Map(ProvinceId(7) -> ProvinceLocation(XCell(0), YCell(0)))


### PR DESCRIPTION
## Summary
- model province features via `FeatureId` and `ProvinceFeature`
- collect province features in `MapState` and encode/render them
- parse `#feature` directives into structured `ProvinceFeature`

## Testing Done
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68abccba06f48327aceaaa99b12f48aa