### PR TITLE
Feature: Support SetLand and Feature directives

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/Arbitraries.scala
@@ -102,6 +102,12 @@ object Arbitraries:
   given Arbitrary[FeatureId] =
     Arbitrary(Gen.choose(0, 1000).map(FeatureId.apply))
 
+  given Arbitrary[SetLand] =
+    Arbitrary(summon[Arbitrary[ProvinceId]].arbitrary.map(SetLand.apply))
+
+  given Arbitrary[Feature] =
+    Arbitrary(summon[Arbitrary[FeatureId]].arbitrary.map(Feature.apply))
+
   given Arbitrary[ProvinceFeature] =
     Arbitrary(for
       p <- summon[Arbitrary[ProvinceId]].arbitrary
@@ -159,6 +165,8 @@ object Arbitraries:
       summon[Arbitrary[Pb]].arbitrary,
       summon[Arbitrary[Terrain]].arbitrary,
       summon[Arbitrary[LandName]].arbitrary,
+      summon[Arbitrary[SetLand]].arbitrary,
+      summon[Arbitrary[Feature]].arbitrary,
       summon[Arbitrary[ProvinceFeature]].arbitrary,
       summon[Arbitrary[Gate]].arbitrary,
       summon[Arbitrary[Neighbour]].arbitrary,

--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapRendererSpec.scala
@@ -36,7 +36,9 @@ object MapRendererSpec extends SimpleIOSuite with Checkers:
     val e7 = expect(LandName(ProvinceId(1), "name").render == "#landname 1 \"name\"")
     val e8 = expect(Gate(ProvinceId(1), ProvinceId(2)).render == "#gate 1 2")
     val e9 = expect(Pb(1, 2, 3, ProvinceId(4)).render == "#pb 1 2 3 4")
-    val e10 = expect(ProvinceFeature(ProvinceId(1), FeatureId(2)).render == "#feature 1 2")
-    val e11 = expect(Comment("note").render == "--note")
-    IO.pure(e1 and e2 and e3 and e4 and e5 and e6 and e7 and e8 and e9 and e10 and e11)
+    val e10 = expect(SetLand(ProvinceId(1)).render == "#setland 1")
+    val e11 = expect(Feature(FeatureId(2)).render == "#feature 2")
+    val e12 = expect(ProvinceFeature(ProvinceId(1), FeatureId(2)).render == "#feature 1 2")
+    val e13 = expect(Comment("note").render == "--note")
+    IO.pure(e1 and e2 and e3 and e4 and e5 and e6 and e7 and e8 and e9 and e10 and e11 and e12 and e13)
   }

--- a/model/src/main/scala/model/map/MapDirective.scala
+++ b/model/src/main/scala/model/map/MapDirective.scala
@@ -42,6 +42,8 @@ final case class SpecStart(nation: Nation, province: ProvinceId) extends MapDire
 final case class Pb(x: Int, y: Int, length: Int, province: ProvinceId) extends MapDirective
 final case class Terrain(province: ProvinceId, mask: Int) extends MapDirective
 final case class LandName(province: ProvinceId, name: String) extends MapDirective
+final case class SetLand(province: ProvinceId) extends MapDirective
+final case class Feature(id: FeatureId) extends MapDirective
 final case class FeatureId(value: Int) extends AnyVal
 final case class ProvinceFeature(province: ProvinceId, id: FeatureId) extends MapDirective
 final case class Gate(a: ProvinceId, b: ProvinceId) extends MapDirective

--- a/model/src/main/scala/model/map/MapDirectiveCodecs.scala
+++ b/model/src/main/scala/model/map/MapDirectiveCodecs.scala
@@ -96,6 +96,7 @@ object MapDirectiveCodecs:
       case WrapAround | HWrapAround | VWrapAround | NoWrapAround       => false
       case _: AllowedPlayer | _: SpecStart | _: Terrain | _: ProvinceFeature | _: Gate      => false
       case Neighbour(_, _) | NeighbourSpec(_, _, _)                    => false
+      case SetLand(_) | Feature(_)                                     => true
       case _                                                           => true
 
   def merge(state: MapState, passThrough: Vector[MapDirective]): Vector[MapDirective] =

--- a/model/src/main/scala/model/map/MapFileParser.scala
+++ b/model/src/main/scala/model/map/MapFileParser.scala
@@ -118,10 +118,16 @@ object MapFileParser:
       Some(LandName(ProvinceId(p), n))
     }
 
-  private def featureP[$: P]: P[Option[MapDirective]] =
+  private def setlandP[$: P]: P[Option[MapDirective]] =
+    P("#setland" ~ ws ~ int).map(p => Some(SetLand(ProvinceId(p))))
+
+  private def provinceFeatureP[$: P]: P[Option[MapDirective]] =
     P("#feature" ~ ws ~ int ~ ws ~ int).map { case (p, f) =>
       Some(ProvinceFeature(ProvinceId(p), FeatureId(f)))
     }
+
+  private def featureP[$: P]: P[Option[MapDirective]] =
+    P("#feature" ~ ws ~ int).map(f => Some(Feature(FeatureId(f))))
 
   private def gateP[$: P]: P[Option[MapDirective]] =
     P("#gate" ~ ws ~ int ~ ws ~ int).map { case (a, b) =>
@@ -166,6 +172,8 @@ object MapFileParser:
       pbP |
       terrainP |
       landnameP |
+      setlandP |
+      provinceFeatureP |
       featureP |
       gateP |
       neighbourP |

--- a/model/src/main/scala/model/map/MapState.scala
+++ b/model/src/main/scala/model/map/MapState.scala
@@ -102,6 +102,8 @@ object MapState:
           adjacency = state.adjacency :+ ((a, b)),
           borders = state.borders :+ Border(a, b, f)
         )
+      case SetLand(_) | Feature(_) =>
+        state
       case _ =>
         state
 
@@ -113,4 +115,5 @@ object MapState:
       case WrapAround | HWrapAround | VWrapAround | NoWrapAround => false
       case _: AllowedPlayer | _: SpecStart | _: Terrain | _: ProvinceFeature | _: Gate => false
       case Neighbour(_, _) | NeighbourSpec(_, _, _)              => false
+      case SetLand(_) | Feature(_)                               => true
       case _                                                     => true

--- a/model/src/main/scala/model/map/Renderer.scala
+++ b/model/src/main/scala/model/map/Renderer.scala
@@ -36,6 +36,8 @@ object Renderer:
         case Pb(x,y,l,p)           => s"#pb $x $y $l ${p.value}"
         case Terrain(p,m)          => s"#terrain ${p.value} $m"
         case LandName(p,n)         => s"#landname ${p.value} \"$n\""
+        case SetLand(p)            => s"#setland ${p.value}"
+        case Feature(f)            => s"#feature ${f.value}"
         case ProvinceFeature(p,f)  => s"#feature ${p.value} ${f.value}"
         case Gate(a,b)             => s"#gate ${a.value} ${b.value}"
         case Neighbour(a,b)        => s"#neighbour ${a.value} ${b.value}"

--- a/model/src/test/scala/model/map/MapStateSpec.scala
+++ b/model/src/test/scala/model/map/MapStateSpec.scala
@@ -19,6 +19,8 @@ object MapStateSpec extends SimpleIOSuite:
     SpecStart(Nation.Atlantis_Early, ProvinceId(42)),
     Terrain(ProvinceId(5), 7),
     LandName(ProvinceId(5), "LN"),
+    SetLand(ProvinceId(8)),
+    Feature(FeatureId(99)),
     ProvinceFeature(ProvinceId(5), FeatureId(9)),
     Gate(ProvinceId(1), ProvinceId(2)),
     Neighbour(ProvinceId(3), ProvinceId(4)),
@@ -57,7 +59,9 @@ object MapStateSpec extends SimpleIOSuite:
         ImageFile("map.tga"),
         Pb(0, 0, 1, ProvinceId(7)),
         Comment("note"),
-        LandName(ProvinceId(5), "LN")
+        LandName(ProvinceId(5), "LN"),
+        SetLand(ProvinceId(8)),
+        Feature(FeatureId(99))
       )
         expect(layer.state == expected && residual == expectedResidual && layer.state == oldState)
     }


### PR DESCRIPTION
## Summary
- add SetLand and Feature directives and renderer support
- parse #setland and #feature lines and preserve them as pass-through
- extend tests and arbitraries for new directive round trips

## Testing
- `sbt compile`
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68abd366460c8327afd6c7bbdeb3ef98