### PR TITLE
Feature: Add Glamour path and update terrain masks

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapModificationServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapModificationServiceSpec.scala
@@ -31,7 +31,7 @@ object MapModificationServiceSpec extends SimpleIOSuite:
       caveOut = dir.resolve("cave-out.map")
       _ <- IO(Files.write(surfaceIn, """#dom2title surface
 #terrain 1 0
-#terrain 2 33554432
+#terrain 2 67108864
 #gate 1 2
 """.getBytes(StandardCharsets.UTF_8)))
       _ <- IO(Files.write(caveIn, """#dom2title cave

--- a/data/duel-map-example.map
+++ b/data/duel-map-example.map
@@ -42,7 +42,7 @@
 #terrain 6 8
 #terrain 7 8388648
 #terrain 8 8388736
-#terrain 9 33554432
+#terrain 9 67108864
 #terrain 10 8388616
 #terrain 11 256
 #terrain 12 33554441

--- a/data/sample-game-map-reader-input/Sample_Latest_Map/test54.map
+++ b/data/sample-game-map-reader-input/Sample_Latest_Map/test54.map
@@ -42,7 +42,7 @@
 #terrain 6 8
 #terrain 7 8388648
 #terrain 8 8388736
-#terrain 9 33554432
+#terrain 9 67108864
 #terrain 10 8388616
 #terrain 11 256
 #terrain 12 33554441

--- a/documentation/domain/dominions/manual/sections/6_map_file_commands/6.4_terrain_type_in_the_map_file.md
+++ b/documentation/domain/dominions/manual/sections/6_map_file_commands/6.4_terrain_type_in_the_map_file.md
@@ -22,12 +22,12 @@ Sets the terrain of a province. The terrain is calculated by adding certain numb
 | 10 | 1024 | Many Sites |
 | 11 | 2048 | Deep Sea |
 | 12 | 4096 | Cave |
-| 22 | 4194304 | Mountains |
-| 24 | 16777216 | Good throne location |
-| 25 | 33554432 | Good start location |
-| 26 | 67108864 | Bad throne location |
-| 29 | 536870912 | Warmer |
-| 30 | 1073741824 | Colder |
+| 23 | 8388608 | Mountains |
+| 25 | 33554432 | Good throne location |
+| 26 | 67108864 | Good start location |
+| 27 | 134217728 | Bad throne location |
+| 30 | 1073741824 | Warmer |
+| 31 | 2147483648 | Colder |
 
 ### Rare Terrain Masks
 
@@ -40,8 +40,9 @@ Sets the terrain of a province. The terrain is calculated by adding certain numb
 | 17 | 131072 | Astral sites |
 | 18 | 262144 | Death sites |
 | 19 | 524288 | Nature sites |
-| 20 | 1048576 | Blood sites |
-| 21 | 2097152 | Holy sites |
+| 20 | 1048576 | Glamour sites |
+| 21 | 2097152 | Blood sites |
+| 22 | 4194304 | Holy sites |
 
 You should use the map editor to set the terrain values as it would be very difficult to do it by hand.
 

--- a/documentation/engineering/architecture/map_modification_services.md
+++ b/documentation/engineering/architecture/map_modification_services.md
@@ -6,7 +6,7 @@ Map modification services inject gate and throne data into Dominions 6 maps. The
 - Accept two input `.map` files representing surface and cave layers.
 - Remove existing `#gate` directives from both maps and append new ones.
 - Update the throne layer so that designated provinces become thrones.
-- Setting a throne modifies the province's `#terrain` bitmask by adding `33554432` which corresponds to `TerrainFlag.GoodStart`.
+ - Setting a throne modifies the province's `#terrain` bitmask by adding `67108864` which corresponds to `TerrainFlag.GoodStart`.
 - Magic numbers are avoided by manipulating `TerrainFlag` values through domain types and helper functions.
 
 ## Domain Types

--- a/model/src/main/scala/model/MagicType.scala
+++ b/model/src/main/scala/model/MagicType.scala
@@ -2,12 +2,13 @@ package com.crib.bills.dom6maps
 package model
 
 enum MagicType(val mask: Int):
-  case Fire   extends MagicType(8192)
-  case Air    extends MagicType(16384)
-  case Water  extends MagicType(32768)
-  case Earth  extends MagicType(65536)
-  case Astral extends MagicType(131072)
-  case Death  extends MagicType(262144)
-  case Nature extends MagicType(524288)
-  case Blood  extends MagicType(1048576)
-  case Holy   extends MagicType(2097152)
+  case Fire    extends MagicType(8192)
+  case Air     extends MagicType(16384)
+  case Water   extends MagicType(32768)
+  case Earth   extends MagicType(65536)
+  case Astral  extends MagicType(131072)
+  case Death   extends MagicType(262144)
+  case Nature  extends MagicType(524288)
+  case Glamour extends MagicType(1048576)
+  case Blood   extends MagicType(2097152)
+  case Holy    extends MagicType(4194304)

--- a/model/src/main/scala/model/TerrainFlag.scala
+++ b/model/src/main/scala/model/TerrainFlag.scala
@@ -16,12 +16,12 @@ enum TerrainFlag(val mask: Int):
   case ManySites         extends TerrainFlag(1024)
   case DeepSea           extends TerrainFlag(2048)
   case Cave              extends TerrainFlag(4096)
-  case Mountains         extends TerrainFlag(4194304)
-  case GoodThrone        extends TerrainFlag(16777216)
-  case GoodStart         extends TerrainFlag(33554432)
-  case BadThrone         extends TerrainFlag(67108864)
-  case Warmer            extends TerrainFlag(536870912)
-  case Colder            extends TerrainFlag(1073741824)
+  case Mountains         extends TerrainFlag(8388608)
+  case GoodThrone        extends TerrainFlag(33554432)
+  case GoodStart         extends TerrainFlag(67108864)
+  case BadThrone         extends TerrainFlag(134217728)
+  case Warmer            extends TerrainFlag(1073741824)
+  case Colder            extends TerrainFlag(-2147483648)
 
 object TerrainFlag:
   val Throne: TerrainFlag = TerrainFlag.GoodStart


### PR DESCRIPTION
Adds Glamour magic path and updates terrain and sample masks to match Dominions 6.

### Testing Done
- `sbt test`

These changes shift Blood and Holy mask values and move mountains and throne-related flags to prevent overlaps. Documentation, sample data, and tests were updated accordingly.

------
https://chatgpt.com/codex/tasks/task_b_68abd3180bec8327a261dad91dac540e