### PR TITLE
Feature: handle saildist and features directives

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/MapFileParserSpec.scala
@@ -1,7 +1,7 @@
 package com.crib.bills.dom6maps
 
 import cats.effect.IO
-import com.crib.bills.dom6maps.model.{BorderFlag, Nation, ProvinceId, TerrainFlag}
+import com.crib.bills.dom6maps.model.{BorderFlag, Nation, ProvinceId, TerrainFlag, MagicType}
 import com.crib.bills.dom6maps.model.map.*
 import fs2.Stream
 import java.nio.charset.StandardCharsets
@@ -46,6 +46,41 @@ object MapFileParserSpec extends SimpleIOSuite:
       .compile
       .toVector
       .attempt
+
+  private val sailDistParsedIO =
+    MapFileParser
+      .parse[IO]
+      .apply(Stream.emits("#saildist 3\n".getBytes(StandardCharsets.UTF_8)).covary[IO])
+      .compile
+      .toVector
+
+  private val featuresParsedIO =
+    MapFileParser
+      .parse[IO]
+      .apply(Stream.emits("#features 7\n".getBytes(StandardCharsets.UTF_8)).covary[IO])
+      .compile
+      .toVector
+
+  private val newNationParsedIO =
+    MapFileParser
+      .parse[IO]
+      .apply(Stream.emits("#allowedplayer 119\n".getBytes(StandardCharsets.UTF_8)).covary[IO])
+      .compile
+      .toVector
+
+  private val goodThroneMaskParsedIO =
+    MapFileParser
+      .parse[IO]
+      .apply(Stream.emits(s"#terrain 1 ${TerrainFlag.GoodThrone.mask}\n".getBytes(StandardCharsets.UTF_8)).covary[IO])
+      .compile
+      .toVector
+
+  private val holyMagicMaskParsedIO =
+    MapFileParser
+      .parse[IO]
+      .apply(Stream.emits(s"#terrain 1 ${MagicType.Holy.mask.toLong}\n".getBytes(StandardCharsets.UTF_8)).covary[IO])
+      .compile
+      .toVector
 
   test("parses sample directives") {
     parsedIO.map { parsed =>
@@ -111,4 +146,24 @@ object MapFileParserSpec extends SimpleIOSuite:
       .toVector
       .attempt
       .map(result => expect(result.isLeft))
+  }
+
+  test("parses saildist directive") {
+    sailDistParsedIO.map(parsed => expect(parsed == Vector(SailDist(3))))
+  }
+
+  test("parses features directive") {
+    featuresParsedIO.map(parsed => expect(parsed == Vector(Features(7))))
+  }
+
+  test("parses new nation IDs") {
+    newNationParsedIO.map(parsed => expect(parsed == Vector(AllowedPlayer(Nation.Feminie_Late))))
+  }
+
+  test("parses GoodThrone terrain flag") {
+    goodThroneMaskParsedIO.map(parsed => expect(parsed == Vector(Terrain(ProvinceId(1), TerrainFlag.GoodThrone.mask))))
+  }
+
+  test("parses Holy magic type mask") {
+    holyMagicMaskParsedIO.map(parsed => expect(parsed == Vector(Terrain(ProvinceId(1), MagicType.Holy.mask.toLong))))
   }

--- a/model/src/main/scala/model/map/MapDirective.scala
+++ b/model/src/main/scala/model/map/MapDirective.scala
@@ -35,6 +35,8 @@ final case class ColorComponent(value: Double) extends AnyVal
 final case class FloatColor(red: ColorComponent, green: ColorComponent, blue: ColorComponent, alpha: ColorComponent)
 final case class MapTextColor(color: FloatColor) extends MapDirective
 final case class MapDomColor(red: Int, green: Int, blue: Int, alpha: Int) extends MapDirective
+final case class SailDist(value: Int) extends MapDirective
+final case class Features(value: Int) extends MapDirective
 
 import com.crib.bills.dom6maps.model.{Nation, ProvinceId, BorderFlag}
 final case class AllowedPlayer(nation: Nation) extends MapDirective

--- a/model/src/main/scala/model/map/MapFileParser.scala
+++ b/model/src/main/scala/model/map/MapFileParser.scala
@@ -99,6 +99,12 @@ object MapFileParser:
       case (r, g, b, a) => Some(MapDomColor(r, g, b, a))
     }
 
+  private def saildistP[$: P]: P[Option[MapDirective]] =
+    P("#saildist" ~ ws ~ int).map(d => Some(SailDist(d)))
+
+  private def featuresP[$: P]: P[Option[MapDirective]] =
+    P("#features" ~ ws ~ int).map(f => Some(Features(f)))
+
   private def allowedPlayerP[$: P]: P[Option[MapDirective]] =
     P("#allowedplayer" ~ ws ~ int).map { n =>
       Nation.byId.get(n).map(AllowedPlayer.apply)
@@ -173,6 +179,8 @@ object MapFileParser:
       mapnohideP |
       maptextcolP |
       mapdomcolP |
+      saildistP |
+      featuresP |
       allowedPlayerP |
       specStartP |
       pbP |

--- a/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
+++ b/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
@@ -3,7 +3,7 @@ package model.map
 
 import cats.effect.IO
 import weaver.SimpleIOSuite
-import model.{ProvinceId, BorderFlag, Nation}
+import model.{ProvinceId, BorderFlag, Nation, TerrainFlag, MagicType}
 import MapDirectiveCodecs.given
 import MapDirectiveCodecs.Encoder
 
@@ -19,9 +19,9 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       wrap = WrapState.HorizontalWrap,
       title = Some(MapTitle("T")),
       description = Some(MapDescription("D")),
-      allowedPlayers = Vector(AllowedPlayer(Nation.Atlantis_Early)),
-      startingPositions = Vector(SpecStart(Nation.Atlantis_Early, ProvinceId(42))),
-      terrains = Vector(Terrain(ProvinceId(5), 7)),
+      allowedPlayers = Vector(AllowedPlayer(Nation.Feminie_Late)),
+      startingPositions = Vector(SpecStart(Nation.Feminie_Late, ProvinceId(42))),
+      terrains = Vector(Terrain(ProvinceId(5), TerrainFlag.GoodThrone.mask | MagicType.Holy.mask.toLong)),
       features = Vector(ProvinceFeature(ProvinceId(5), FeatureId(9))),
       gates = Vector(Gate(ProvinceId(1), ProvinceId(2))),
       provinceLocations = ProvinceLocations.empty
@@ -32,9 +32,9 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       HWrapAround,
       Dom2Title("T"),
       Description("D"),
-      AllowedPlayer(Nation.Atlantis_Early),
-      SpecStart(Nation.Atlantis_Early, ProvinceId(42)),
-      Terrain(ProvinceId(5), 7),
+      AllowedPlayer(Nation.Feminie_Late),
+      SpecStart(Nation.Feminie_Late, ProvinceId(42)),
+      Terrain(ProvinceId(5), TerrainFlag.GoodThrone.mask | MagicType.Holy.mask.toLong),
       ProvinceFeature(ProvinceId(5), FeatureId(9)),
       Gate(ProvinceId(1), ProvinceId(2)),
       Neighbour(ProvinceId(3), ProvinceId(4)),
@@ -42,4 +42,11 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
     )
 
     IO.pure(expect(Encoder[MapState].encode(state) == expected))
+  }
+
+  test("merges pass-through directives") {
+    val state = MapState.empty
+    val pass = Vector(SailDist(2), Features(7))
+    val expected = Vector(NoWrapAround) ++ pass
+    IO.pure(expect(MapDirectiveCodecs.merge(state, pass) == expected))
   }


### PR DESCRIPTION
## Summary
- support parsing of `#saildist` and `#features` directives
- exercise new Nation, TerrainFlag, and MagicType enum branches

## Testing Done
- `sbt test`
- `sbt clean coverage test`
- `sbt coverageReport`


------
https://chatgpt.com/codex/tasks/task_b_68ac8e7e9c748327843f2b34bd9dcedf