### PR TITLE
Fix: Remove diagonal wrap adjacency

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverService.scala
@@ -26,11 +26,10 @@ object WrapSeverService:
   ): Boolean =
     (index.locationOf(a), index.locationOf(b)) match
       case (Some(locA), Some(locB)) =>
-        val left = 0
+        val left  = 0
         val right = width.value - 1
-        locA.y.value == locB.y.value &&
-          ((locA.x.value == left && locB.x.value == right) ||
-            (locA.x.value == right && locB.x.value == left))
+        (locA.x.value == left && locB.x.value == right) ||
+          (locA.x.value == right && locB.x.value == left)
       case _ => false
 
   def severVertically(state: MapState): MapState =

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceDuelPipeSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceDuelPipeSpec.scala
@@ -85,3 +85,45 @@ object GroundSurfaceDuelPipeSpec extends SimpleIOSuite:
         expect(surfChecks && caveChecks)
       })
     yield result
+
+  test("pipe removes diagonal adjacencies across wraps"):
+    val size = MapSize.from(5).toOption.get
+    val locations = ProvinceLocations.fromProvinceIdMap(
+      Map(
+        ProvinceId(5) -> ProvinceLocation(XCell(4), YCell(0)),
+        ProvinceId(6) -> ProvinceLocation(XCell(0), YCell(1)),
+        ProvinceId(7) -> ProvinceLocation(XCell(1), YCell(1))
+      )
+    )
+    val base = MapState.empty.copy(
+      size = Some(size),
+      adjacency = Vector((ProvinceId(5), ProvinceId(6)), (ProvinceId(6), ProvinceId(7))),
+      wrap = WrapState.FullWrap,
+      provinceLocations = locations
+    )
+    import cats.instances.either.*
+    type EC[A] = Either[Throwable, A]
+    val pipe = new apps.services.mapeditor.GroundSurfaceDuelPipeImpl[IO](
+      new apps.services.mapeditor.MapSizeValidatorStub[IO](size, base, base),
+      new apps.services.mapeditor.PlacementPlannerStub[IO](Vector.empty, Vector.empty),
+      new apps.services.mapeditor.GateDirectiveServiceStub[IO],
+      new apps.services.mapeditor.ThronePlacementServiceStub[IO],
+      new apps.services.mapeditor.SpawnPlacementServiceStub[IO]
+    )
+    for
+      res <- pipe.apply[EC](
+        base,
+        base,
+        GroundSurfaceDuelConfig.default,
+        SurfaceNation(Nation.Atlantis_Early),
+        UndergroundNation(Nation.Mictlan_Early)
+      )
+      result <- IO.fromEither(res.map { case (surfRes, caveRes) =>
+        val pair      = (ProvinceId(5), ProvinceId(6))
+        val interior  = (ProvinceId(6), ProvinceId(7))
+        val removed   = !surfRes.adjacency.contains(pair) && !caveRes.adjacency.contains(pair)
+        val kept      = surfRes.adjacency.contains(interior) && caveRes.adjacency.contains(interior)
+        val wrapsGone = surfRes.wrap == WrapState.NoWrap && caveRes.wrap == WrapState.NoWrap
+        expect(removed && kept && wrapsGone)
+      })
+    yield result


### PR DESCRIPTION
## Summary
- allow WrapSeverService to sever left-right diagonals by mirroring top-bottom logic
- expand wrap severing tests to cover diagonal adjacencies
- ensure duel pipeline removes diagonal adjacencies after wraps are severed

## Testing
- `sbt compile`
- `sbt "project apps" "testOnly com.crib.bills.dom6maps.apps.services.mapeditor.WrapSeverServiceSpec com.crib.bills.dom6maps.services.mapeditor.GroundSurfaceDuelPipeSpec"`


------
https://chatgpt.com/codex/tasks/task_b_68ac9e1c1398832780fdddcd122db289