### PR TITLE
[Feature]: Coordinate-based throne placement

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/PlacementPlanner.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/PlacementPlanner.scala
@@ -10,7 +10,7 @@ trait PlacementPlanner[Sequencer[_]]:
 class PlacementPlannerImpl[Sequencer[_]] extends PlacementPlanner[Sequencer]:
   override def plan(size: MapSize, config: GroundSurfaceDuelConfig): (Vector[GateSpec], Vector[ThronePlacement]) =
     val mids = EdgeMidpoints.of(size)
-    val corners = CornerProvinces.all(size)
+    val corners = CornerLocations.all(size)
     val offset = size.value * size.value
     val gates = Vector(
       GateSpec(mids.top, ProvinceId(mids.top.value + offset)),
@@ -19,7 +19,7 @@ class PlacementPlannerImpl[Sequencer[_]] extends PlacementPlanner[Sequencer]:
       GateSpec(mids.right, ProvinceId(mids.right.value + offset))
     )
     val level = config.throneLevel
-    val thrones = corners.map(p => ThronePlacement(p, level))
+    val thrones = corners.map(loc => ThronePlacement(loc, level))
     (gates, thrones)
 
 class PlacementPlannerStub[Sequencer[_]](

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneConfiguration.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneConfiguration.scala
@@ -3,13 +3,15 @@ package apps.services.mapeditor
 
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.*
-import model.ProvinceId
-import model.map.{ThronePlacement, ThroneLevel}
+import model.map.{ProvinceLocation, ThronePlacement, ThroneLevel, XCell, YCell}
 
 final case class ThroneConfiguration(overrides: Vector[ThronePlacement]) derives ConfigReader
 
 object ThroneConfiguration:
-  given ConfigReader[ProvinceId] = ConfigReader[Int].map(ProvinceId(_))
+  given ConfigReader[XCell] = ConfigReader[Int].map(XCell(_))
+  given ConfigReader[YCell] = ConfigReader[Int].map(YCell(_))
+  given ConfigReader[ProvinceLocation] =
+    ConfigReader.forProduct2("x", "y")((x: XCell, y: YCell) => ProvinceLocation(x, y))
   given ConfigReader[ThroneLevel] = ConfigReader[Int].map(ThroneLevel(_))
   given ConfigReader[ThronePlacement] =
-    ConfigReader.forProduct2("province", "level")((p: ProvinceId, l: ThroneLevel) => ThronePlacement(p, l))
+    ConfigReader.forProduct3("x", "y", "level")((x: XCell, y: YCell, l: ThroneLevel) => ThronePlacement(ProvinceLocation(x, y), l))

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureView.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureView.scala
@@ -23,8 +23,8 @@ class ThroneFeatureViewImpl[Sequencer[_]](using Sync[Sequencer])
   private val configFileName = "throne-override.conf"
   private val sampleConfig =
     """overrides = [
-  { province = 1, level = 3 },
-  { province = 15, level = 1 }
+  { x = 0, y = 0, level = 3 },
+  { x = 4, y = 2, level = 1 }
 ]
 """
   private val sequencer = summon[Sync[Sequencer]]
@@ -39,9 +39,9 @@ class ThroneFeatureViewImpl[Sequencer[_]](using Sync[Sequencer])
         val p = new JPanel()
         p.setLayout(new BoxLayout(p, BoxLayout.Y_AXIS))
         val summary =
-          s"""Random L1: ${config.randomLevelOne.map(_.value).mkString(",")}
-Random L2: ${config.randomLevelTwo.map(_.value).mkString(",")}
-Fixed: ${config.fixed.map(p => s"${p.province.value}:${p.level.value}").mkString(",")}"""
+          s"""Random L1: ${config.randomLevelOne.map(l => s"(${l.x.value},${l.y.value})").mkString(",")}
+Random L2: ${config.randomLevelTwo.map(l => s"(${l.x.value},${l.y.value})").mkString(",")}
+Fixed: ${config.fixed.map(p => s"(${p.location.x.value},${p.location.y.value}):${p.level.value}").mkString(",")}"""
         p.add(new JLabel(summary))
         p
       }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/MapEditorWrapAppSpec.scala
@@ -157,6 +157,10 @@ dest="${destRoot.toString}"
 #dom2title test
 #imagefile test.tga
 #mapsize 1280 800
+#pb 0 0 1 1
+#pb 1024 0 1 5
+#pb 0 640 1 21
+#pb 1024 640 1 25
 #wraparound
 #terrain 1 0
 #terrain 5 0

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceDuelPipeSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/GroundSurfaceDuelPipeSpec.scala
@@ -18,6 +18,10 @@ object GroundSurfaceDuelPipeSpec extends SimpleIOSuite:
       Gate(ProvinceId(1), ProvinceId(2)),
       AllowedPlayer(Nation.Agartha_Early),
       SpecStart(Nation.Agartha_Early, ProvinceId(1)),
+      Pb(0, 0, 1, ProvinceId(1)),
+      Pb(4 * 256, 0, 1, ProvinceId(5)),
+      Pb(0, 4 * 160, 1, ProvinceId(21)),
+      Pb(4 * 256, 4 * 160, 1, ProvinceId(25)),
       Terrain(ProvinceId(1), 0),
       Terrain(ProvinceId(5), 0),
       Terrain(ProvinceId(21), 0),
@@ -29,6 +33,10 @@ object GroundSurfaceDuelPipeSpec extends SimpleIOSuite:
       Gate(ProvinceId(2), ProvinceId(3)),
       AllowedPlayer(Nation.Ulm_Early),
       SpecStart(Nation.Ulm_Early, ProvinceId(1)),
+      Pb(0, 0, 1, ProvinceId(1)),
+      Pb(4 * 256, 0, 1, ProvinceId(5)),
+      Pb(0, 4 * 160, 1, ProvinceId(21)),
+      Pb(4 * 256, 4 * 160, 1, ProvinceId(25)),
       Terrain(ProvinceId(1), 0),
       Terrain(ProvinceId(5), 0),
       Terrain(ProvinceId(21), 0),
@@ -60,11 +68,18 @@ object GroundSurfaceDuelPipeSpec extends SimpleIOSuite:
           Gate(ProvinceId(11), ProvinceId(36)),
           Gate(ProvinceId(15), ProvinceId(40))
         )
-        val thrones = Vector(1, 5, 21, 25).map(ProvinceId.apply)
+        val thrones = Vector(
+          ProvinceLocation(XCell(0), YCell(0)),
+          ProvinceLocation(XCell(4), YCell(0)),
+          ProvinceLocation(XCell(0), YCell(4)),
+          ProvinceLocation(XCell(4), YCell(4))
+        )
         val center = ProvinceId(13)
         def hasThrones(state: MapState) =
-          thrones.forall { id =>
-            state.terrains.exists { case Terrain(p, m) if p == id => TerrainMask(m).hasFlag(TerrainFlag.Throne); case _ => false }
+          thrones.forall { loc =>
+            state.provinceLocations.provinceIdAt(loc).exists { id =>
+              state.terrains.exists { case Terrain(p, m) if p == id => TerrainMask(m).hasFlag(TerrainFlag.Throne); case _ => false }
+            }
           }
         val surfChecks =
           gates.forall(surfRes.gates.contains) &&

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapModificationServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/MapModificationServiceSpec.scala
@@ -10,7 +10,7 @@ import java.nio.charset.StandardCharsets
 import model.ProvinceId
 import model.{TerrainFlag, TerrainMask}
 import model.map.{Gate, Terrain, MapFileParser}
-import model.map.{GateSpec, ThronePlacement, ThroneLevel}
+import model.map.{GateSpec, ThronePlacement, ThroneLevel, ProvinceLocation, XCell, YCell}
 
 object MapModificationServiceSpec extends SimpleIOSuite:
   type EC[A] = Either[Throwable, A]
@@ -22,7 +22,7 @@ object MapModificationServiceSpec extends SimpleIOSuite:
     val writer = new MapWriterImpl[IO]
     val service = new MapModificationServiceImpl[IO](loader, gateService, throneService, writer)
     val gates = Vector(GateSpec(ProvinceId(3), ProvinceId(4)))
-    val thrones = Vector(ThronePlacement(ProvinceId(1), ThroneLevel(1)))
+    val thrones = Vector(ThronePlacement(ProvinceLocation(XCell(0), YCell(0)), ThroneLevel(1)))
     for
       dir <- IO(Files.createTempDirectory("maps"))
       surfaceIn = dir.resolve("surface.map")
@@ -30,6 +30,9 @@ object MapModificationServiceSpec extends SimpleIOSuite:
       surfaceOut = dir.resolve("surface-out.map")
       caveOut = dir.resolve("cave-out.map")
       _ <- IO(Files.write(surfaceIn, """#dom2title surface
+#mapsize 1280 800
+#pb 0 0 1 1
+#pb 256 0 1 2
 #terrain 1 0
 #terrain 2 67108864
 #gate 1 2

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/PlacementPlannerSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/PlacementPlannerSpec.scala
@@ -19,6 +19,11 @@ object PlacementPlannerSpec extends SimpleIOSuite:
       GateSpec(ProvinceId(11), ProvinceId(36)),
       GateSpec(ProvinceId(15), ProvinceId(40))
     )
-    val expectedThrones = Vector(1, 5, 21, 25).map(p => ThronePlacement(ProvinceId(p), ThroneLevel(1)))
+    val expectedThrones = Vector(
+      ProvinceLocation(XCell(0), YCell(0)),
+      ProvinceLocation(XCell(4), YCell(0)),
+      ProvinceLocation(XCell(0), YCell(4)),
+      ProvinceLocation(XCell(4), YCell(4))
+    ).map(loc => ThronePlacement(loc, ThroneLevel(1)))
     expect(gates == expectedGates && thrones == expectedThrones).pure[IO]
   }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneConfigurationSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneConfigurationSpec.scala
@@ -6,15 +6,14 @@ import weaver.SimpleIOSuite
 import pureconfig.*
 import java.nio.file.Files
 import java.nio.charset.StandardCharsets
-import model.ProvinceId
-import model.map.{ThronePlacement, ThroneLevel}
+import model.map.{ThronePlacement, ThroneLevel, ProvinceLocation, XCell, YCell}
 
 object ThroneConfigurationSpec extends SimpleIOSuite:
   test("parses overrides config") {
     val contents =
       """overrides = [
-        { province = 1, level = 2 },
-        { province = 5, level = 3 }
+        { x = 0, y = 0, level = 2 },
+        { x = 4, y = 0, level = 3 }
       ]"""
     for
       file <- IO(Files.createTempFile("throne", ".conf"))
@@ -22,8 +21,8 @@ object ThroneConfigurationSpec extends SimpleIOSuite:
       cfg <- IO(ConfigSource.file(file).loadOrThrow[ThroneConfiguration])
       expected = ThroneConfiguration(
         Vector(
-          ThronePlacement(ProvinceId(1), ThroneLevel(2)),
-          ThronePlacement(ProvinceId(5), ThroneLevel(3))
+          ThronePlacement(ProvinceLocation(XCell(0), YCell(0)), ThroneLevel(2)),
+          ThronePlacement(ProvinceLocation(XCell(4), YCell(0)), ThroneLevel(3))
         )
       )
     yield expect(cfg == expected)

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureServiceSpec.scala
@@ -9,7 +9,7 @@ import java.nio.file.Files
 import java.nio.charset.StandardCharsets
 import model.ProvinceId
 import model.{TerrainFlag, TerrainMask}
-import model.map.{Terrain, ThroneFeatureConfig, ThronePlacement, ThroneLevel, MapFileParser}
+import model.map.{Terrain, ThroneFeatureConfig, ThronePlacement, ThroneLevel, MapFileParser, ProvinceLocation, XCell, YCell}
 
 object ThroneFeatureServiceSpec extends SimpleIOSuite:
   type EC[A] = Either[Throwable, A]
@@ -20,9 +20,9 @@ object ThroneFeatureServiceSpec extends SimpleIOSuite:
     val writer = new MapWriterImpl[IO]
     val service = new ThroneFeatureServiceImpl[IO](loader, throneService, writer)
     val config = ThroneFeatureConfig(
-      randomLevelOne = Vector(ProvinceId(2)),
-      randomLevelTwo = Vector(ProvinceId(3)),
-      fixed = Vector(ThronePlacement(ProvinceId(4), ThroneLevel(2)))
+      randomLevelOne = Vector(ProvinceLocation(XCell(1), YCell(0))),
+      randomLevelTwo = Vector(ProvinceLocation(XCell(2), YCell(0))),
+      fixed = Vector(ThronePlacement(ProvinceLocation(XCell(3), YCell(0)), ThroneLevel(2)))
     )
     for
       dir <- IO(Files.createTempDirectory("thrones"))
@@ -30,6 +30,11 @@ object ThroneFeatureServiceSpec extends SimpleIOSuite:
       out = dir.resolve("out.map")
       _ <- IO(Files.write(in,
         """#dom2title test
+#mapsize 1280 800
+#pb 0 0 1 1
+#pb 256 0 1 2
+#pb 512 0 1 3
+#pb 768 0 1 4
 #terrain 1 67108864
 #terrain 2 0
 #terrain 3 0

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
@@ -6,16 +6,25 @@ import cats.syntax.all.*
 import weaver.SimpleIOSuite
 import model.ProvinceId
 import model.{TerrainFlag, TerrainMask}
-import model.map.{MapState, Terrain, ThronePlacement, ThroneLevel}
+import model.map.{MapState, Terrain, ThronePlacement, ThroneLevel, ProvinceLocation, ProvinceLocations, XCell, YCell}
 
 object ThronePlacementServiceSpec extends SimpleIOSuite:
   test("update sets and clears throne flag") {
     val service = new ThronePlacementServiceImpl[IO]
-    val state = MapState.empty.copy(terrains = Vector(
-      Terrain(ProvinceId(1), 0),
-      Terrain(ProvinceId(2), TerrainFlag.Throne.mask)
-    ))
-    val placements = Vector(ThronePlacement(ProvinceId(1), ThroneLevel(1)))
+    val locations = ProvinceLocations.fromProvinceIdMap(
+      Map(
+        ProvinceId(1) -> ProvinceLocation(XCell(0), YCell(0)),
+        ProvinceId(2) -> ProvinceLocation(XCell(1), YCell(0))
+      )
+    )
+    val state = MapState.empty.copy(
+      terrains = Vector(
+        Terrain(ProvinceId(1), 0),
+        Terrain(ProvinceId(2), TerrainFlag.Throne.mask)
+      ),
+      provinceLocations = locations
+    )
+    val placements = Vector(ThronePlacement(ProvinceLocation(XCell(0), YCell(0)), ThroneLevel(1)))
     for
       res <- service.update(state, placements)
       mask1 = res.terrains.collectFirst { case Terrain(ProvinceId(1), m) => TerrainMask(m) }.get

--- a/documentation/engineering/architecture/ground_surface_duel_service.md
+++ b/documentation/engineering/architecture/ground_surface_duel_service.md
@@ -15,7 +15,7 @@ The Ground-Surface Duel service composes map modification capabilities to genera
 ## Domain Types
 - `MapSize`: value class wrapping an odd `Int` side length with constructor validation.
 - `EdgeMidpoints`: pure function computing midpoint province identifiers for a given `MapSize`.
-- `CornerProvinces`: pure function returning the four corner province identifiers.
+- `CornerLocations`: pure function returning the four corner coordinates.
 - `CenterProvince`: pure function returning the central province identifier.
 - `SurfaceNation` and `UndergroundNation`: value classes wrapping `Nation`.
 - `PlayerSpawn`: nation and province pair for `allowedplayer`/`specstart` placement.
@@ -28,7 +28,7 @@ The Ground-Surface Duel service composes map modification capabilities to genera
 2. **PlacementPlanner**
    - Uses `MapSize` to derive:
      - `Vector[GateSpec]` linking surface and cave midpoints.
-     - `Vector[ThronePlacement]` for corner provinces on each layer.
+     - `Vector[ThronePlacement]` for corner coordinates on each layer.
    - Pure and side-effect free.
 3. **GroundSurfaceDuelPipe**
    - Orchestrates transformation of both states.
@@ -61,7 +61,7 @@ The Ground-Surface Duel service composes map modification capabilities to genera
 
 ## Testing Strategy
 - Provide `Stub` instances for all capabilities to verify pure placement logic using in-memory `MapState` values.
-- Integration tests compose real services to confirm that gates, thrones, and severing appear in the expected provinces for a small sample map.
+- Integration tests compose real services to confirm that gates, thrones, and severing appear at the expected coordinates for a small sample map.
 - Run `sbt compile` as a sanity check for documentation changes.
 
 [Back to Architecture Guide Index](README.md)

--- a/documentation/engineering/architecture/map_modification_services.md
+++ b/documentation/engineering/architecture/map_modification_services.md
@@ -5,14 +5,14 @@ Map modification services inject gate and throne data into Dominions 6 maps. The
 ## Requirements
 - Accept two input `.map` files representing surface and cave layers.
 - Remove existing `#gate` directives from both maps and append new ones.
-- Update the throne layer so that designated provinces become thrones.
+- Update the throne layer so that provinces at designated coordinates become thrones.
 - Setting a throne modifies the province's `#terrain` bitmask by adding `67108864` which corresponds to `TerrainFlag.GoodStart`.
 - Magic numbers are avoided by manipulating `TerrainFlag` values through domain types and helper functions.
 
 ## Domain Types
 - `GateSpec`: pairs of `ProvinceId` values describing a gate connection.
 - `ThroneLevel`: value class wrapping an `Int` representing throne strength.
-- `ThronePlacement`: province identifier and throne level.
+- `ThronePlacement`: `ProvinceLocation` and throne level.
 - `TerrainMask`: value class wrapping a `Long` with methods:
   - `withFlag(flag: TerrainFlag): TerrainMask`
   - `withoutFlag(flag: TerrainFlag): TerrainMask`
@@ -35,7 +35,7 @@ Map modification services inject gate and throne data into Dominions 6 maps. The
    - Replaces existing gates in a `MapState` with new ones from `Vector[GateSpec]`.
 3. **ThronePlacementService**
    - Accepts `Vector[ThronePlacement]` and rewrites `Terrain` entries in `MapState` by toggling flags via `TerrainMask`.
-   - Ensures non-specified provinces have throne flags cleared.
+   - Ensures provinces not resolved from placements have throne flags cleared.
 4. **MapModificationService**
    - Higher-order orchestrator that:
      1. Loads surface and cave layers via `MapLayerLoader`.

--- a/documentation/engineering/architecture/throne_feature_plan.md
+++ b/documentation/engineering/architecture/throne_feature_plan.md
@@ -3,14 +3,14 @@
 This plan describes how to apply throne placements to a map layer using existing services.
 
 ## Goals
-- Enable random level 1 thrones in designated provinces.
-- Enable random level 2 thrones in designated provinces.
-- Apply specific thrones to explicitly paired provinces.
+- Enable random level 1 thrones in designated coordinates.
+- Enable random level 2 thrones in designated coordinates.
+- Apply specific thrones to explicitly paired coordinates.
 
 ## Plan
 1. **Model Input**
-   - Convert province identifiers to `ProvinceId`.
-   - For random lists, map each province to `ThronePlacement(province, ThroneLevel(1))` or `ThroneLevel(2)`.
+   - Convert coordinate pairs to `ProvinceLocation`.
+   - For random lists, map each location to `ThronePlacement(location, ThroneLevel(1))` or `ThroneLevel(2)`.
    - For fixed pairs, map to `ThronePlacement` using the given level.
 2. **Combine Placements**
    - Concatenate the three vectors into one `Vector[ThronePlacement]`.
@@ -18,7 +18,7 @@ This plan describes how to apply throne placements to a map layer using existing
    - Parse the target map layer via `MapLayerLoader` to obtain a `MapState`.
 4. **Apply Thrones**
    - Call `ThronePlacementService.update` with the current `MapState` and combined placements.
-   - The service toggles `TerrainFlag.Throne` on designated provinces and clears it elsewhere.
+   - The service toggles `TerrainFlag.Throne` on provinces resolved from the designated coordinates and clears it elsewhere.
 5. **Persist Changes**
    - Use `MapWriter` or the higher-level `MapModificationService` to render the updated map layer to disk.
 
@@ -27,8 +27,8 @@ This plan describes how to apply throne placements to a map layer using existing
   - When checked the view writes a sample configuration file `throne-override.conf`:
     ```
     overrides = [
-      { province = 1, level = 3 },
-      { province = 15, level = 1 }
+      { x = 0, y = 0, level = 3 },
+      { x = 4, y = 2, level = 1 }
     ]
     ```
     The file is parsed into a `ThroneConfiguration` once the user confirms the dialog.

--- a/model/src/main/scala/model/map/CornerLocations.scala
+++ b/model/src/main/scala/model/map/CornerLocations.scala
@@ -1,0 +1,22 @@
+package com.crib.bills.dom6maps
+package model.map
+
+final case class CornerLocations(
+    topLeft: ProvinceLocation,
+    topRight: ProvinceLocation,
+    bottomLeft: ProvinceLocation,
+    bottomRight: ProvinceLocation
+)
+
+object CornerLocations:
+  def of(size: MapSize): CornerLocations =
+    val n = size.value
+    val topLeft = ProvinceLocation(XCell(0), YCell(0))
+    val topRight = ProvinceLocation(XCell(n - 1), YCell(0))
+    val bottomLeft = ProvinceLocation(XCell(0), YCell(n - 1))
+    val bottomRight = ProvinceLocation(XCell(n - 1), YCell(n - 1))
+    CornerLocations(topLeft, topRight, bottomLeft, bottomRight)
+
+  def all(size: MapSize): Vector[ProvinceLocation] =
+    val c = of(size)
+    Vector(c.topLeft, c.topRight, c.bottomLeft, c.bottomRight)

--- a/model/src/main/scala/model/map/ThroneFeatureConfig.scala
+++ b/model/src/main/scala/model/map/ThroneFeatureConfig.scala
@@ -1,14 +1,12 @@
 package com.crib.bills.dom6maps
 package model.map
 
-import model.ProvinceId
-
 final case class ThroneFeatureConfig(
-    randomLevelOne: Vector[ProvinceId],
-    randomLevelTwo: Vector[ProvinceId],
+    randomLevelOne: Vector[ProvinceLocation],
+    randomLevelTwo: Vector[ProvinceLocation],
     fixed: Vector[ThronePlacement]
 ):
   def placements: Vector[ThronePlacement] =
-    randomLevelOne.map(p => ThronePlacement(p, ThroneLevel(1))) ++
-      randomLevelTwo.map(p => ThronePlacement(p, ThroneLevel(2))) ++
+    randomLevelOne.map(loc => ThronePlacement(loc, ThroneLevel(1))) ++
+      randomLevelTwo.map(loc => ThronePlacement(loc, ThroneLevel(2))) ++
       fixed

--- a/model/src/main/scala/model/map/ThronePlacement.scala
+++ b/model/src/main/scala/model/map/ThronePlacement.scala
@@ -1,6 +1,4 @@
 package com.crib.bills.dom6maps
 package model.map
 
-import model.ProvinceId
-
-final case class ThronePlacement(province: ProvinceId, level: ThroneLevel)
+final case class ThronePlacement(location: ProvinceLocation, level: ThroneLevel)

--- a/model/src/test/scala/model/map/CornerLocationsSpec.scala
+++ b/model/src/test/scala/model/map/CornerLocationsSpec.scala
@@ -1,0 +1,18 @@
+package com.crib.bills.dom6maps
+package model.map
+
+import cats.effect.IO
+import weaver.SimpleIOSuite
+
+object CornerLocationsSpec extends SimpleIOSuite:
+  test("CornerLocations.all returns corner coordinates") {
+    val size = MapSize.from(5).toOption.get
+    val corners = CornerLocations.all(size)
+    val expected = Vector(
+      ProvinceLocation(XCell(0), YCell(0)),
+      ProvinceLocation(XCell(4), YCell(0)),
+      ProvinceLocation(XCell(0), YCell(4)),
+      ProvinceLocation(XCell(4), YCell(4))
+    )
+    IO.pure(expect(corners == expected))
+  }


### PR DESCRIPTION
## Summary
- Track throne locations with map coordinates instead of province IDs
- Update throne configuration, view, and placement services for coordinate-based lookup
- Document and plan ground-surface duel throne placement using corner coordinates

## Testing
- `sbt "project model" test`
- `sbt "project apps" test`


------
https://chatgpt.com/codex/tasks/task_b_68af7af510d883279ff64d35ab18e27c