### PR TITLE
Feature: throne feature directives

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
@@ -6,7 +6,18 @@ import cats.syntax.all.*
 import weaver.SimpleIOSuite
 import model.ProvinceId
 import model.{TerrainFlag, TerrainMask}
-import model.map.{MapState, Terrain, ThronePlacement, ThroneLevel, ProvinceLocation, ProvinceLocations, XCell, YCell}
+import model.map.{
+  FeatureId,
+  MapState,
+  ProvinceFeature,
+  Terrain,
+  ThronePlacement,
+  ThroneLevel,
+  ProvinceLocation,
+  ProvinceLocations,
+  XCell,
+  YCell
+}
 
 object ThronePlacementServiceSpec extends SimpleIOSuite:
   test("update sets and clears throne flag") {
@@ -31,6 +42,7 @@ object ThronePlacementServiceSpec extends SimpleIOSuite:
       mask2 = res.terrains.collectFirst { case Terrain(ProvinceId(2), m) => TerrainMask(m) }.get
     yield expect.all(
       mask1.hasFlag(TerrainFlag.Throne),
-      !mask2.hasFlag(TerrainFlag.Throne)
+      !mask2.hasFlag(TerrainFlag.Throne),
+      res.features == Vector(ProvinceFeature(ProvinceId(1), FeatureId(5001)))
     )
   }

--- a/model/src/main/scala/model/map/MapDirectiveCodecs.scala
+++ b/model/src/main/scala/model/map/MapDirectiveCodecs.scala
@@ -56,7 +56,7 @@ object MapDirectiveCodecs:
 
   given Encoder[ProvinceFeature] with
     def encode(value: ProvinceFeature): Vector[MapDirective] =
-      Vector(value)
+      Vector(SetLand(value.province), Feature(value.id))
 
   given Encoder[Gate] with
     def encode(value: Gate): Vector[MapDirective] =

--- a/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
+++ b/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
@@ -35,7 +35,8 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       AllowedPlayer(Nation.Feminie_Late),
       SpecStart(Nation.Feminie_Late, ProvinceId(42)),
       Terrain(ProvinceId(5), TerrainFlag.GoodThrone.mask | MagicType.Holy.mask.toLong),
-      ProvinceFeature(ProvinceId(5), FeatureId(9)),
+      SetLand(ProvinceId(5)),
+      Feature(FeatureId(9)),
       Gate(ProvinceId(1), ProvinceId(2)),
       Neighbour(ProvinceId(3), ProvinceId(4)),
       NeighbourSpec(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)


### PR DESCRIPTION
## Summary
- map throne levels to sample feature ids and record province features when applying placements
- encode throne features as `#setland`/`#feature` pairs during map write
- verify throne feature directives round-trip through placement and service layers

## Testing
- `sbt test`


------
https://chatgpt.com/codex/tasks/task_b_68b11808b6e883279aa8d09834b93cc7