### PR TITLE
Fix: sever horizontal neighbors regardless of wrap

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapConversionService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapConversionService.scala
@@ -27,12 +27,16 @@ class WrapConversionServiceImpl[Sequencer[_]: Sync] extends WrapConversionServic
       case WrapChoice.HWrap =>
         WrapSeverService.severVertically(state).copy(wrap = WrapState.HorizontalWrap)
       case WrapChoice.VWrap =>
-        WrapSeverService.severHorizontally(state).copy(wrap = WrapState.VerticalWrap)
+        WrapSeverService
+          .severHorizontally(state)
+          .copy(wrap = WrapState.VerticalWrap)
       case WrapChoice.FullWrap =>
         state.copy(wrap = WrapState.FullWrap)
       case WrapChoice.NoWrap =>
         WrapSeverService
-          .severHorizontally(WrapSeverService.severVertically(state))
+          .severHorizontally(
+            WrapSeverService.severVertically(state)
+          )
           .copy(wrap = WrapState.NoWrap)
       case WrapChoice.GroundSurfaceDuel => state
     sequencer.delay(println(s"Converting map to $target")).as(errorChannel.pure(result))

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverService.scala
@@ -56,16 +56,9 @@ object WrapSeverService:
   def severHorizontally(state: MapState): MapState =
     state.size match
       case Some(sz) =>
-        val width = MapWidth(sz.value)
-        val shouldSever = state.wrap == WrapState.FullWrap || state.wrap == WrapState.HorizontalWrap
-        val newAdj =
-          if shouldSever then
-            state.adjacency.filterNot((a, b) => isLeftRight(a, b, state.provinceLocations, width))
-          else state.adjacency
-        val newBorders =
-          if shouldSever then
-            state.borders.filterNot(b => isLeftRight(b.a, b.b, state.provinceLocations, width))
-          else state.borders
+        val width      = MapWidth(sz.value)
+        val newAdj     = state.adjacency.filterNot((a, b) => isLeftRight(a, b, state.provinceLocations, width))
+        val newBorders = state.borders.filterNot(b => isLeftRight(b.a, b.b, state.provinceLocations, width))
         val newWrap = state.wrap match
           case WrapState.FullWrap       => WrapState.VerticalWrap
           case WrapState.HorizontalWrap => WrapState.NoWrap

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/WrapSeverServiceSpec.scala
@@ -97,3 +97,66 @@ object WrapSeverServiceSpec extends SimpleIOSuite:
     val hasMiddle = result.adjacency.contains((ProvinceId(6), ProvinceId(7)))
     IO.pure(expect(result.wrap == WrapState.VerticalWrap && !hasDiagonal && hasMiddle))
   }
+
+  test("severHorizontally removes left-right neighbours when wrap is HorizontalWrap") {
+    val size = MapSize.from(5).toOption
+    val locations = ProvinceLocations.fromProvinceIdMap(
+      Map(
+        ProvinceId(5) -> model.map.ProvinceLocation(model.map.XCell(4), model.map.YCell(0)),
+        ProvinceId(6) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(1)),
+        ProvinceId(7) -> model.map.ProvinceLocation(model.map.XCell(1), model.map.YCell(1))
+      )
+    )
+    val state = MapState.empty.copy(
+      size = size,
+      adjacency = Vector((ProvinceId(5), ProvinceId(6)), (ProvinceId(6), ProvinceId(7))),
+      wrap = WrapState.HorizontalWrap,
+      provinceLocations = locations
+    )
+    val result = WrapSeverService.severHorizontally(state)
+    val hasLeftRight = result.adjacency.contains((ProvinceId(5), ProvinceId(6)))
+    val hasMiddle    = result.adjacency.contains((ProvinceId(6), ProvinceId(7)))
+    IO.pure(expect(result.wrap == WrapState.NoWrap && !hasLeftRight && hasMiddle))
+  }
+
+  test("severHorizontally removes left-right neighbours when wrap is VerticalWrap") {
+    val size = MapSize.from(5).toOption
+    val locations = ProvinceLocations.fromProvinceIdMap(
+      Map(
+        ProvinceId(5) -> model.map.ProvinceLocation(model.map.XCell(4), model.map.YCell(0)),
+        ProvinceId(6) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(1)),
+        ProvinceId(7) -> model.map.ProvinceLocation(model.map.XCell(1), model.map.YCell(1))
+      )
+    )
+    val state = MapState.empty.copy(
+      size = size,
+      adjacency = Vector((ProvinceId(5), ProvinceId(6)), (ProvinceId(6), ProvinceId(7))),
+      wrap = WrapState.VerticalWrap,
+      provinceLocations = locations
+    )
+    val result = WrapSeverService.severHorizontally(state)
+    val hasLeftRight = result.adjacency.contains((ProvinceId(5), ProvinceId(6)))
+    val hasMiddle    = result.adjacency.contains((ProvinceId(6), ProvinceId(7)))
+    IO.pure(expect(result.wrap == WrapState.VerticalWrap && !hasLeftRight && hasMiddle))
+  }
+
+  test("severHorizontally removes left-right neighbours when wrap is NoWrap") {
+    val size = MapSize.from(5).toOption
+    val locations = ProvinceLocations.fromProvinceIdMap(
+      Map(
+        ProvinceId(5) -> model.map.ProvinceLocation(model.map.XCell(4), model.map.YCell(0)),
+        ProvinceId(6) -> model.map.ProvinceLocation(model.map.XCell(0), model.map.YCell(1)),
+        ProvinceId(7) -> model.map.ProvinceLocation(model.map.XCell(1), model.map.YCell(1))
+      )
+    )
+    val state = MapState.empty.copy(
+      size = size,
+      adjacency = Vector((ProvinceId(5), ProvinceId(6)), (ProvinceId(6), ProvinceId(7))),
+      wrap = WrapState.NoWrap,
+      provinceLocations = locations
+    )
+    val result = WrapSeverService.severHorizontally(state)
+    val hasLeftRight = result.adjacency.contains((ProvinceId(5), ProvinceId(6)))
+    val hasMiddle    = result.adjacency.contains((ProvinceId(6), ProvinceId(7)))
+    IO.pure(expect(result.wrap == WrapState.NoWrap && !hasLeftRight && hasMiddle))
+  }


### PR DESCRIPTION
## Summary
- remove wrap guard so horizontal severing always prunes left-right neighbors
- sever horizontally without normalizing map state to `FullWrap`
- add tests covering all initial wrap states

## Testing
- ⚠️ `sbt scalafmtAll` (Not a valid command: scalafmtAll)
- ✅ `sbt compile`
- ✅ `sbt "project apps" "testOnly com.crib.bills.dom6maps.apps.services.mapeditor.WrapSeverServiceSpec com.crib.bills.dom6maps.apps.services.mapeditor.WrapConversionServiceSpec"`


------
https://chatgpt.com/codex/tasks/task_b_68b1f1cc31c08327bea5dfa05a0206d4