### PR TITLE
Feature: Magic Site Parser

### DIFF
--- a/model/src/main/scala/model/dominions/SiteParser.scala
+++ b/model/src/main/scala/model/dominions/SiteParser.scala
@@ -1,0 +1,71 @@
+package com.crib.bills.dom6maps
+package model.dominions
+
+import cats.effect.Sync
+import fs2.{Pipe, Pull, Stream}
+import fs2.io.file.{Files, Path}
+import fs2.text
+
+object SiteParser:
+  final case class SiteName(value: String) extends AnyVal
+  final case class SiteNumber(value: Int) extends AnyVal
+  final case class Rarity(value: Int) extends AnyVal
+  final case class MagicPath(value: String) extends AnyVal
+  final case class Site(name: SiteName, number: SiteNumber, rarity: Rarity, path: MagicPath)
+
+  def parseFile[F[_]: Sync](path: Path)(using Files[F]): Stream[F, Site] =
+    Files[F].readAll(path).through(parse)
+
+  def parse[F[_]: Sync]: Pipe[F, Byte, Site] =
+    _.through(text.utf8.decode)
+      .through(text.lines)
+      .through(lines)
+
+  private def lines[F[_]]: Pipe[F, String, Site] = in =>
+    def go(s: Stream[F, String], acc: Partial): Pull[F, Site, Unit] =
+      s.pull.uncons1.flatMap {
+        case Some((line, tail)) =>
+          val trimmed = line.trim
+          if trimmed.isEmpty then
+            acc.toSite match
+              case Some(site) => Pull.output1(site) >> go(tail, Partial())
+              case None       => go(tail, Partial())
+          else
+            go(tail, Partial.update(acc, trimmed))
+        case None =>
+          acc.toSite match
+            case Some(site) => Pull.output1(site)
+            case None       => Pull.done
+      }
+    go(in, Partial()).stream
+
+  private final case class Partial(
+      name: Option[SiteName] = None,
+      number: Option[SiteNumber] = None,
+      rarity: Option[Rarity] = None,
+      path: Option[MagicPath] = None
+  ):
+    def toSite: Option[Site] =
+      for
+        n <- name
+        num <- number
+        r <- rarity
+        p <- path
+      yield Site(n, num, r, p)
+
+  private object Partial:
+    private val namePattern = raw"^(.*)\((\d+)\)$$".r
+    private val pathPattern = raw"^path:\s*(.*)$$".r
+    private val rarityPattern = raw"^rarity:\s*(\d+)$$".r
+
+    def apply(): Partial = new Partial()
+
+    def update(partial: Partial, line: String): Partial =
+      line match
+        case namePattern(n, num) =>
+          partial.copy(name = Some(SiteName(n.trim)), number = Some(SiteNumber(num.toInt)))
+        case pathPattern(p) =>
+          partial.copy(path = Some(MagicPath(p.trim)))
+        case rarityPattern(r) =>
+          partial.copy(rarity = Some(Rarity(r.toInt)))
+        case _ => partial

--- a/model/src/test/scala/model/dominions/SiteParserSpec.scala
+++ b/model/src/test/scala/model/dominions/SiteParserSpec.scala
@@ -1,0 +1,40 @@
+package com.crib.bills.dom6maps
+package model.dominions
+
+import cats.effect.IO
+import fs2.Stream
+import java.nio.charset.StandardCharsets
+import weaver.SimpleIOSuite
+
+object SiteParserSpec extends SimpleIOSuite:
+  test("parses a site block") {
+    val input =
+      """The Silver Throne(1364)
+        |  com1: 100
+        |  domspread: 2
+        |  gold: 200
+        |  level: 0
+        |  loc: 16607
+        |  path: Holy
+        |  rarity: 12
+        |  sprite: 95
+        |  throne: 1
+        |
+        |""".stripMargin
+
+    val result = Stream
+      .emits(input.getBytes(StandardCharsets.UTF_8))
+      .through(SiteParser.parse[IO])
+      .compile
+      .toList
+
+    result.map { sites =>
+      val expected = SiteParser.Site(
+        SiteParser.SiteName("The Silver Throne"),
+        SiteParser.SiteNumber(1364),
+        SiteParser.Rarity(12),
+        SiteParser.MagicPath("Holy")
+      )
+      expect(sites == List(expected))
+    }
+  }


### PR DESCRIPTION
## Summary
- add streaming parser for Dominions magic site data
- cover parsing with a unit test

## Testing
- `sbt "project model" test`


------
https://chatgpt.com/codex/tasks/task_b_68b249ba6f44832791c3721d5ada58dc