### PR TITLE
Feature: Support throne id overrides

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneConfiguration.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneConfiguration.scala
@@ -3,7 +3,14 @@ package apps.services.mapeditor
 
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.*
-import model.map.{ProvinceLocation, ThronePlacement, ThroneLevel, XCell, YCell}
+import model.map.{
+  FeatureId,
+  ProvinceLocation,
+  ThronePlacement,
+  ThroneLevel,
+  XCell,
+  YCell
+}
 
 final case class ThroneConfiguration(overrides: Vector[ThronePlacement]) derives ConfigReader
 
@@ -13,5 +20,14 @@ object ThroneConfiguration:
   given ConfigReader[ProvinceLocation] =
     ConfigReader.forProduct2("x", "y")((x: XCell, y: YCell) => ProvinceLocation(x, y))
   given ConfigReader[ThroneLevel] = ConfigReader[Int].map(ThroneLevel(_))
+  given ConfigReader[FeatureId] = ConfigReader[Int].map(FeatureId(_))
   given ConfigReader[ThronePlacement] =
-    ConfigReader.forProduct3("x", "y", "level")((x: XCell, y: YCell, l: ThroneLevel) => ThronePlacement(ProvinceLocation(x, y), l))
+    ConfigReader.forProduct4("x", "y", "level", "id")(
+      (x: XCell, y: YCell, l: Option[ThroneLevel], id: Option[FeatureId]) =>
+        (l, id) match
+          case (Some(level), None) => ThronePlacement(ProvinceLocation(x, y), level)
+          case (None, Some(fid))   => ThronePlacement(ProvinceLocation(x, y), fid)
+          case _ =>
+            throw new IllegalArgumentException("Specify either level or id for throne placement")
+    )
+

--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapChoiceService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/WrapChoiceService.scala
@@ -36,9 +36,16 @@ class WrapChoiceServiceImpl[Sequencer[_]](using Sync[Sequencer])
           _ <- sequencer.delay(cavePanel.setEnabledAll(false))
           caveBox <- sequencer.delay(new JCheckBox("modify cave layer"))
           throneSummary <- sequencer.delay {
+            val fixedSummary = config.fixed
+              .map { p =>
+                val spec =
+                  p.level.map(l => l.value.toString).orElse(p.id.map(fid => s"id=${fid.value}")).getOrElse("?")
+                s"(${p.location.x.value},${p.location.y.value}):$spec"
+              }
+              .mkString(",")
             s"""Random L1: ${config.randomLevelOne.map(l => s"(${l.x.value},${l.y.value})").mkString(",")}
 Random L2: ${config.randomLevelTwo.map(l => s"(${l.x.value},${l.y.value})").mkString(",")}
-Fixed: ${config.fixed.map(p => s"(${p.location.x.value},${p.location.y.value}):${p.level.value}").mkString(",")}"""
+Fixed: $fixedSummary"""
           }
           throneLabel <- sequencer.delay(new JLabel(throneSummary))
           throneBox <- sequencer.delay(new JCheckBox("Override Thrones"))

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneConfigurationSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneConfigurationSpec.scala
@@ -6,14 +6,21 @@ import weaver.SimpleIOSuite
 import pureconfig.*
 import java.nio.file.Files
 import java.nio.charset.StandardCharsets
-import model.map.{ThronePlacement, ThroneLevel, ProvinceLocation, XCell, YCell}
+import model.map.{
+  FeatureId,
+  ThronePlacement,
+  ThroneLevel,
+  ProvinceLocation,
+  XCell,
+  YCell
+}
 
 object ThroneConfigurationSpec extends SimpleIOSuite:
   test("parses overrides config") {
     val contents =
       """overrides = [
         { x = 0, y = 0, level = 2 },
-        { x = 4, y = 0, level = 3 }
+        { x = 4, y = 0, id = 1358 }
       ]"""
     for
       file <- IO(Files.createTempFile("throne", ".conf"))
@@ -22,7 +29,7 @@ object ThroneConfigurationSpec extends SimpleIOSuite:
       expected = ThroneConfiguration(
         Vector(
           ThronePlacement(ProvinceLocation(XCell(0), YCell(0)), ThroneLevel(2)),
-          ThronePlacement(ProvinceLocation(XCell(4), YCell(0)), ThroneLevel(3))
+          ThronePlacement(ProvinceLocation(XCell(4), YCell(0)), FeatureId(1358))
         )
       )
     yield expect(cfg == expected)

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
@@ -46,3 +46,19 @@ object ThronePlacementServiceSpec extends SimpleIOSuite:
       res.features == Vector(ProvinceFeature(ProvinceId(1), FeatureId(5001)))
     )
   }
+
+  test("explicit feature id is applied") {
+    val service = new ThronePlacementServiceImpl[IO]
+    val locations = ProvinceLocations.fromProvinceIdMap(
+      Map(
+        ProvinceId(1) -> ProvinceLocation(XCell(0), YCell(0))
+      )
+    )
+    val state = MapState.empty.copy(provinceLocations = locations)
+    val placements = Vector(
+      ThronePlacement(ProvinceLocation(XCell(0), YCell(0)), FeatureId(1358))
+    )
+    for
+      res <- service.update(state, placements)
+    yield expect(res.features == Vector(ProvinceFeature(ProvinceId(1), FeatureId(1358))))
+  }

--- a/documentation/engineering/architecture/throne_feature_plan.md
+++ b/documentation/engineering/architecture/throne_feature_plan.md
@@ -29,10 +29,10 @@ This plan describes how to apply throne placements to a map layer using existing
     ```
     overrides = [
       { x = 0, y = 0, level = 3 },
-      { x = 4, y = 2, level = 1 }
+      { x = 4, y = 2, id = 1358 }
     ]
     ```
-    The file is parsed into a `ThroneConfiguration` once the user confirms the dialog.
+    Each placement may specify either a throne `level` or a specific throne `id` and is parsed into a `ThroneConfiguration` once the user confirms the dialog.
   - If the box is unchecked no file is produced and only the in-memory selections are used.
 - `ThroneFeatureService` composes the resulting configuration with other chosen operations before applying and persisting changes.
 

--- a/model/src/main/scala/model/map/ThronePlacement.scala
+++ b/model/src/main/scala/model/map/ThronePlacement.scala
@@ -1,4 +1,20 @@
 package com.crib.bills.dom6maps
 package model.map
 
-final case class ThronePlacement(location: ProvinceLocation, level: ThroneLevel)
+final case class ThronePlacement(
+    location: ProvinceLocation,
+    level: Option[ThroneLevel],
+    id: Option[FeatureId]
+)
+
+object ThronePlacement:
+  import scala.annotation.targetName
+
+  @targetName("fromLevel")
+  def apply(location: ProvinceLocation, level: ThroneLevel): ThronePlacement =
+    new ThronePlacement(location, Some(level), None)
+
+  @targetName("fromId")
+  def apply(location: ProvinceLocation, id: FeatureId): ThronePlacement =
+    new ThronePlacement(location, None, Some(id))
+


### PR DESCRIPTION
## Summary
- allow override config to specify explicit throne ids or levels
- display throne id or level in override summary
- document throne id option

## Testing
- `sbt test`

------
https://chatgpt.com/codex/tasks/task_b_68b353b8682c8327af6eab8633ebfe11