### PR TITLE
Fix: Use real throne feature ids

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureService.scala
@@ -7,6 +7,7 @@ import fs2.io.file.{Files, Path}
 import cats.effect.Sync
 import model.map.{MapDirective, SetLand, Feature, FeatureId, ThroneFeatureConfig}
 import scala.annotation.tailrec
+import model.dominions.{Feature as DomFeature}
 
 trait ThroneFeatureService[Sequencer[_]]:
   def apply[ErrorChannel[_]](
@@ -24,11 +25,13 @@ class ThroneFeatureServiceImpl[Sequencer[_]: Sync](
 ) extends ThroneFeatureService[Sequencer]:
   protected val sequencer = summon[Sync[Sequencer]]
 
+  private val throneIds: Set[Int] = DomFeature.thrones.map(_.id.value).toSet
+
   private def stripThroneFeatures(passThrough: Vector[MapDirective]): Vector[MapDirective] =
     @tailrec
     def loop(remaining: List[MapDirective], acc: Vector[MapDirective]): Vector[MapDirective] =
       remaining match
-        case SetLand(_) :: Feature(id) :: tail if id.value >= 5000 =>
+        case SetLand(_) :: Feature(id) :: tail if throneIds.contains(id.value) =>
           loop(tail, acc)
         case head :: tail =>
           loop(tail, acc :+ head)

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureServiceSpec.scala
@@ -52,9 +52,9 @@ object ThroneFeatureServiceSpec extends SimpleIOSuite:
 #terrain 3 0
 #terrain 4 0
 #setland 1
-#feature 5001
+#feature 1332
 #setland 2
-#feature 5003
+#feature 1383
 """.getBytes(StandardCharsets.UTF_8)))
       resultEC <- service.apply[EC](Path.fromNioPath(in), config, Path.fromNioPath(out))
       _ <- IO.fromEither(resultEC)
@@ -77,8 +77,8 @@ object ThroneFeatureServiceSpec extends SimpleIOSuite:
       mask3.hasFlag(TerrainFlag.Throne),
       mask4.hasFlag(TerrainFlag.Throne),
       f1.isEmpty,
-      f2 == Vector(FeatureId(5001)),
-      f3 == Vector(FeatureId(5002)),
-      f4 == Vector(FeatureId(5002))
+      f2 == Vector(FeatureId(1332)),
+      f3 == Vector(FeatureId(1359)),
+      f4 == Vector(FeatureId(1359))
     )
   }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
@@ -43,7 +43,7 @@ object ThronePlacementServiceSpec extends SimpleIOSuite:
     yield expect.all(
       mask1.hasFlag(TerrainFlag.Throne),
       !mask2.hasFlag(TerrainFlag.Throne),
-      res.features == Vector(ProvinceFeature(ProvinceId(1), FeatureId(5001)))
+      res.features == Vector(ProvinceFeature(ProvinceId(1), FeatureId(1332)))
     )
   }
 


### PR DESCRIPTION
## Summary
- select genuine Dominions throne features by level instead of hardcoded placeholders
- strip existing throne features using official feature ids
- update throne placement and feature service specs to expect actual throne ids

## Testing
- `sbt compile`
- `sbt "project apps" "testOnly com.crib.bills.dom6maps.apps.services.mapeditor.ThronePlacementServiceSpec com.crib.bills.dom6maps.apps.services.mapeditor.ThroneFeatureServiceSpec"`


------
https://chatgpt.com/codex/tasks/task_b_68b38d55970483278bb7d2a59b31eba9