### PR TITLE
Fix: Randomize throne placement features

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThroneFeatureServiceSpec.scala
@@ -22,6 +22,7 @@ import model.map.{
   XCell,
   YCell
 }
+import model.dominions.{Feature as DomFeature}
 
 object ThroneFeatureServiceSpec extends SimpleIOSuite:
   type EC[A] = Either[Throwable, A]
@@ -76,14 +77,19 @@ object ThroneFeatureServiceSpec extends SimpleIOSuite:
       f2 = featuresFor(ProvinceId(2))
       f3 = featuresFor(ProvinceId(3))
       f4 = featuresFor(ProvinceId(4))
+      levelOneIds = DomFeature.levelOneThrones.map(_.id.value).toSet
+      levelTwoIds = DomFeature.levelTwoThrones.map(_.id.value).toSet
     yield expect.all(
       !mask1.hasFlag(TerrainFlag.Throne),
       mask2.hasFlag(TerrainFlag.Throne),
       mask3.hasFlag(TerrainFlag.Throne),
       mask4.hasFlag(TerrainFlag.Throne),
       f1 == Vector(FeatureId(100)),
-      f2 == Vector(FeatureId(1332)),
-      f3 == Vector(FeatureId(1359)),
-      f4 == Vector(FeatureId(1359))
+      f2.size == 1,
+      levelOneIds.contains(f2.head.value),
+      f3.size == 1,
+      levelTwoIds.contains(f3.head.value),
+      f4.size == 1,
+      levelTwoIds.contains(f4.head.value)
     )
   }

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
@@ -18,6 +18,7 @@ import model.map.{
   XCell,
   YCell
 }
+import model.dominions.{Feature as DomFeature}
 
 object ThronePlacementServiceSpec extends SimpleIOSuite:
   test("update sets and clears throne flag") {
@@ -40,10 +41,13 @@ object ThronePlacementServiceSpec extends SimpleIOSuite:
       res <- service.update(state, placements)
       mask1 = res.terrains.collectFirst { case Terrain(ProvinceId(1), m) => TerrainMask(m) }.get
       mask2 = res.terrains.collectFirst { case Terrain(ProvinceId(2), m) => TerrainMask(m) }.get
+      throneIds = DomFeature.levelOneThrones.map(_.id.value).toSet
+      featureIdOpt = res.features.collectFirst { case ProvinceFeature(ProvinceId(1), fid) => fid }
     yield expect.all(
       mask1.hasFlag(TerrainFlag.Throne),
       !mask2.hasFlag(TerrainFlag.Throne),
-      res.features == Vector(ProvinceFeature(ProvinceId(1), FeatureId(1332)))
+      res.features.size == 1,
+      featureIdOpt.exists(fid => throneIds.contains(fid.value))
     )
   }
 


### PR DESCRIPTION
## Summary
- Randomize throne feature selection per level
- Update throne placement tests for non-deterministic IDs

## Testing
- `sbt "project apps" test`


------
https://chatgpt.com/codex/tasks/task_b_68b394096d008327bec4150f6c4c3f3a