### PR TITLE
Fix: encode border adjacency pairs

### DIFF
--- a/model/src/main/scala/model/map/MapDirectiveCodecs.scala
+++ b/model/src/main/scala/model/map/MapDirectiveCodecs.scala
@@ -81,10 +81,9 @@ object MapDirectiveCodecs:
       val terrains = value.terrains.flatMap(Encoder[Terrain].encode)
       val features = value.features.flatMap(Encoder[ProvinceFeature].encode)
       val gates = value.gates.flatMap(Encoder[Gate].encode)
-      val borderPairs = value.borders.map(b => (b.a, b.b)).toSet
-      val adjacency = value.adjacency
-        .filterNot(borderPairs.contains)
-        .flatMap(Encoder[(ProvinceId, ProvinceId)].encode)
+      val adjacencyPairs =
+        (value.adjacency ++ value.borders.map(b => (b.a, b.b))).distinct
+      val adjacency = adjacencyPairs.flatMap(Encoder[(ProvinceId, ProvinceId)].encode)
       val borders = value.borders.flatMap(Encoder[Border].encode)
       size ++ wrap ++ title ++ description ++ players ++ starts ++ terrains ++ features ++ gates ++ adjacency ++ borders
 

--- a/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
+++ b/model/src/test/scala/model/map/MapDirectiveCodecsSpec.scala
@@ -13,6 +13,7 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       size = MapSize.from(5).toOption,
       adjacency = Vector(
         (ProvinceId(3), ProvinceId(4)),
+        (ProvinceId(5), ProvinceId(6)),
         (ProvinceId(5), ProvinceId(6))
       ),
       borders = Vector(Border(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)),
@@ -39,6 +40,7 @@ object MapDirectiveCodecsSpec extends SimpleIOSuite:
       Feature(FeatureId(9)),
       Gate(ProvinceId(1), ProvinceId(2)),
       Neighbour(ProvinceId(3), ProvinceId(4)),
+      Neighbour(ProvinceId(5), ProvinceId(6)),
       NeighbourSpec(ProvinceId(5), ProvinceId(6), BorderFlag.MountainPass)
     )
 


### PR DESCRIPTION
## Summary
- include border pairs when encoding adjacency
- deduplicate adjacency and emit both `Neighbour` and `NeighbourSpec` directives

## Testing
- `sbt "project model" compile`
- `sbt "project model" "testOnly com.crib.bills.dom6maps.model.map.MapDirectiveCodecsSpec"`


------
https://chatgpt.com/codex/tasks/task_b_68b3c17a41788327985815842c31b420