### PR TITLE
Fix: Preserve existing province features during throne placement

### DIFF
--- a/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementService.scala
+++ b/apps/src/main/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementService.scala
@@ -65,10 +65,14 @@ class ThronePlacementServiceImpl[Sequencer[_]: Sync] extends ThronePlacementServ
             else TerrainMask(mask).withoutFlag(TerrainFlag.Throne)
           t.copy(mask = updated.value)
       }
-      features = resolved.map { case (province, fid) =>
+      existingFeatures = state.features.filterNot(pf => throneSet.contains(pf.province))
+      newFeatures = resolved.map { case (province, fid) =>
         ProvinceFeature(province, fid)
       }
-      updatedState = state.copy(terrains = updatedTerrains, features = features)
+      updatedState = state.copy(
+        terrains = updatedTerrains,
+        features = existingFeatures ++ newFeatures
+      )
       _ <- sequencer.delay(println(s"Placing ${resolved.size} thrones"))
     yield updatedState
 

--- a/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/services/mapeditor/ThronePlacementServiceSpec.scala
@@ -34,6 +34,7 @@ object ThronePlacementServiceSpec extends SimpleIOSuite:
         Terrain(ProvinceId(1), 0),
         Terrain(ProvinceId(2), TerrainFlag.Throne.mask)
       ),
+      features = Vector(ProvinceFeature(ProvinceId(2), FeatureId(200))),
       provinceLocations = locations
     )
     val placements = Vector(ThronePlacement(ProvinceLocation(XCell(0), YCell(0)), ThroneLevel(1)))
@@ -43,11 +44,13 @@ object ThronePlacementServiceSpec extends SimpleIOSuite:
       mask2 = res.terrains.collectFirst { case Terrain(ProvinceId(2), m) => TerrainMask(m) }.get
       throneIds = DomFeature.levelOneThrones.map(_.id.value).toSet
       featureIdOpt = res.features.collectFirst { case ProvinceFeature(ProvinceId(1), fid) => fid }
+      feature2 = res.features.collectFirst { case ProvinceFeature(ProvinceId(2), fid) => fid }
     yield expect.all(
       mask1.hasFlag(TerrainFlag.Throne),
       !mask2.hasFlag(TerrainFlag.Throne),
-      res.features.size == 1,
-      featureIdOpt.exists(fid => throneIds.contains(fid.value))
+      res.features.size == 2,
+      featureIdOpt.exists(fid => throneIds.contains(fid.value)),
+      feature2.contains(FeatureId(200))
     )
   }
 


### PR DESCRIPTION
## Summary
- retain non-targeted province features when adding thrones
- verify throne placement keeps existing features

## Testing Done
- `sbt "project apps" "testOnly com.crib.bills.dom6maps.apps.services.mapeditor.ThronePlacementServiceSpec"`


------
https://chatgpt.com/codex/tasks/task_b_68b4a0be8a1883278528dcb5d05002dc