### PR TITLE
Feature: reproduce full-wrap throne placement failure

### DIFF
--- a/apps/src/test/scala/com/crib/bills/dom6maps/apps/FullWrapThronePlacementSpec.scala
+++ b/apps/src/test/scala/com/crib/bills/dom6maps/apps/FullWrapThronePlacementSpec.scala
@@ -1,0 +1,96 @@
+package com.crib.bills.dom6maps
+package apps
+
+import cats.effect.IO
+import cats.syntax.all.*
+import cats.{MonadError, Traverse}
+import fs2.io.file.Path
+import model.map.{MapFileParser, MapState, FeatureId}
+import services.mapeditor.{
+  GroundSurfaceDuelPipe,
+  ThronePlacementServiceImpl,
+  MapLayerLoaderImpl,
+  WrapChoice,
+  WrapChoiceService,
+  WrapChoices,
+  MapEditorSettings,
+  GroundSurfaceNationService
+}
+import weaver.SimpleIOSuite
+import java.nio.file.{Files => JFiles, Path => JPath}
+
+object FullWrapThronePlacementSpec extends SimpleIOSuite:
+  override def maxParallelism = 1
+
+  private class StubWrapChoiceService(selections: WrapChoices) extends WrapChoiceService[IO]:
+    override def chooseSettings[ErrorChannel[_]](
+        config: model.map.ThroneFeatureConfig
+    )(using MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]) =
+      IO.pure(summon[MonadError[ErrorChannel, Throwable]].pure(MapEditorSettings(selections, config)))
+
+  private class StubGroundSurfaceNationService extends GroundSurfaceNationService[IO]:
+    override def chooseNations[ErrorChannel[_]]()(using MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]) =
+      IO.pure(summon[MonadError[ErrorChannel, Throwable]].pure(model.map.DuelNations(model.map.SurfaceNation(model.Nation.Agartha_Early), model.map.UndergroundNation(model.Nation.Atlantis_Early))))
+
+  private class StubGroundSurfaceDuelPipe extends GroundSurfaceDuelPipe[IO]:
+    override def apply[ErrorChannel[_]](
+        surface: model.map.MapState,
+        cave: model.map.MapState,
+        config: model.map.GroundSurfaceDuelConfig,
+        surfaceNation: model.map.SurfaceNation,
+        undergroundNation: model.map.UndergroundNation
+    )(using MonadError[ErrorChannel, Throwable] & Traverse[ErrorChannel]) =
+      (model.map.MapState.empty, model.map.MapState.empty).pure[ErrorChannel].pure[IO]
+
+  test("places overridden thrones for full wrap") {
+    val overrides =
+      """overrides = [
+        { x = 0, y = 0, level = 2 },
+        { x = 6, y = 0, level = 2 },
+        { x = 0, y = 6, level = 2 },
+        { x = 6, y = 6, level = 2 },
+
+        { x = 3, y = 0, level = 1 },
+        { x = 9, y = 0, level = 1 },
+        { x = 3, y = 6, level = 1 },
+        { x = 9, y = 6, level = 1 },
+
+        { x = 0, y = 3, level = 1 },
+        { x = 6, y = 3, level = 1 },
+        { x = 0, y = 9, level = 1 },
+        { x = 6, y = 9, id = 1338 }
+      ]
+      """.stripMargin
+    for
+      rootDir <- IO(JFiles.createTempDirectory("wrap-src"))
+      latest <- IO(JFiles.createDirectory(rootDir.resolve("latest")))
+      _ <- IO(JFiles.copy(Path("data/eight-by-eight.map").toNioPath, latest.resolve("map.map")))
+      _ <- IO(JFiles.write(latest.resolve("image.tga"), Array[Byte](1,2,3)))
+      destRoot <- IO(JFiles.createTempDirectory("wrap-dest"))
+      configFile = JPath.of("map-editor-wrap.conf")
+      _ <- IO(
+        JFiles.writeString(
+          configFile,
+          s"""source="${rootDir.toString}"
+             |dest="${destRoot.toString}"
+             |""".stripMargin
+        )
+      )
+      overridesFile = JPath.of("throne-override.conf")
+      _ <- IO(JFiles.writeString(overridesFile, overrides))
+      _ <- MapEditorWrapApp
+        .runWith(
+          new MapLayerLoaderImpl[IO],
+          new StubWrapChoiceService(WrapChoices(WrapChoice.FullWrap, None)),
+          new StubGroundSurfaceNationService,
+          new StubGroundSurfaceDuelPipe,
+          new ThronePlacementServiceImpl[IO]
+        )
+        .guarantee(IO(JFiles.deleteIfExists(configFile)) *> IO(JFiles.deleteIfExists(overridesFile)))
+      destDir = Path.fromNioPath(destRoot.resolve("latest"))
+      mapPath = destDir / "map.map"
+      directives <- MapFileParser.parseFile[IO](mapPath).compile.toVector
+      state <- MapState.fromDirectives(fs2.Stream.emits(directives).covary[IO])
+      features = state.features
+    yield expect.all(features.length == 12, features.exists(_.id == FeatureId(1338)))
+  }

--- a/data/eight-by-eight.map
+++ b/data/eight-by-eight.map
@@ -1,0 +1,133 @@
+-- Map
+#dom2title test
+#imagefile test.tga
+#mapsize 2048 1280
+#pb 0 0 1 1
+#pb 256 0 1 2
+#pb 512 0 1 3
+#pb 768 0 1 4
+#pb 1024 0 1 5
+#pb 1280 0 1 6
+#pb 1536 0 1 7
+#pb 1792 0 1 8
+#pb 0 160 1 9
+#pb 256 160 1 10
+#pb 512 160 1 11
+#pb 768 160 1 12
+#pb 1024 160 1 13
+#pb 1280 160 1 14
+#pb 1536 160 1 15
+#pb 1792 160 1 16
+#pb 0 320 1 17
+#pb 256 320 1 18
+#pb 512 320 1 19
+#pb 768 320 1 20
+#pb 1024 320 1 21
+#pb 1280 320 1 22
+#pb 1536 320 1 23
+#pb 1792 320 1 24
+#pb 0 480 1 25
+#pb 256 480 1 26
+#pb 512 480 1 27
+#pb 768 480 1 28
+#pb 1024 480 1 29
+#pb 1280 480 1 30
+#pb 1536 480 1 31
+#pb 1792 480 1 32
+#pb 0 640 1 33
+#pb 256 640 1 34
+#pb 512 640 1 35
+#pb 768 640 1 36
+#pb 1024 640 1 37
+#pb 1280 640 1 38
+#pb 1536 640 1 39
+#pb 1792 640 1 40
+#pb 0 800 1 41
+#pb 256 800 1 42
+#pb 512 800 1 43
+#pb 768 800 1 44
+#pb 1024 800 1 45
+#pb 1280 800 1 46
+#pb 1536 800 1 47
+#pb 1792 800 1 48
+#pb 0 960 1 49
+#pb 256 960 1 50
+#pb 512 960 1 51
+#pb 768 960 1 52
+#pb 1024 960 1 53
+#pb 1280 960 1 54
+#pb 1536 960 1 55
+#pb 1792 960 1 56
+#pb 0 1120 1 57
+#pb 256 1120 1 58
+#pb 512 1120 1 59
+#pb 768 1120 1 60
+#pb 1024 1120 1 61
+#pb 1280 1120 1 62
+#pb 1536 1120 1 63
+#pb 1792 1120 1 64
+#wraparound
+#terrain 1 0
+#terrain 2 0
+#terrain 3 0
+#terrain 4 0
+#terrain 5 0
+#terrain 6 0
+#terrain 7 0
+#terrain 8 0
+#terrain 9 0
+#terrain 10 0
+#terrain 11 0
+#terrain 12 0
+#terrain 13 0
+#terrain 14 0
+#terrain 15 0
+#terrain 16 0
+#terrain 17 0
+#terrain 18 0
+#terrain 19 0
+#terrain 20 0
+#terrain 21 0
+#terrain 22 0
+#terrain 23 0
+#terrain 24 0
+#terrain 25 0
+#terrain 26 0
+#terrain 27 0
+#terrain 28 0
+#terrain 29 0
+#terrain 30 0
+#terrain 31 0
+#terrain 32 0
+#terrain 33 0
+#terrain 34 0
+#terrain 35 0
+#terrain 36 0
+#terrain 37 0
+#terrain 38 0
+#terrain 39 0
+#terrain 40 0
+#terrain 41 0
+#terrain 42 0
+#terrain 43 0
+#terrain 44 0
+#terrain 45 0
+#terrain 46 0
+#terrain 47 0
+#terrain 48 0
+#terrain 49 0
+#terrain 50 0
+#terrain 51 0
+#terrain 52 0
+#terrain 53 0
+#terrain 54 0
+#terrain 55 0
+#terrain 56 0
+#terrain 57 0
+#terrain 58 0
+#terrain 59 0
+#terrain 60 0
+#terrain 61 0
+#terrain 62 0
+#terrain 63 0
+#terrain 64 0


### PR DESCRIPTION
## Summary
- add 8x8 sample map for full-wrap tests
- add full-wrap throne override test demonstrating missing throne placements

## Testing
- `sbt compile`
- `sbt "project apps" test` *(fails: assertion failed: features.length == 12)*

------
https://chatgpt.com/codex/tasks/task_b_68b4a92ce1308327a2432d9a8131b9d0