### PR TITLE
Fix: Document throne defender limitations

### DIFF
--- a/documentation/domain/dominions/province_features.md
+++ b/documentation/domain/dominions/province_features.md
@@ -13,6 +13,11 @@ Province features are assigned by pairing a province selection with a feature id
 
 `#setland` selects the province to modify without removing its existing units. `#feature` then adds a feature such as a throne or unique site to that province. For example, `#setland 120` followed by `#feature 1358` adds the *Throne of Winter* to province 120.
 
+## Throne Defenders
+
+Placing a throne with `#feature` only adds the site. Standard throne defenders are not created. The manual notes that changing province properties does not alter independent defenders and that any desired defenders must be assigned manually using [Commander Commands](manual/update/sections/6_map_file_commands/6.8_commander_commands.md) after selecting the province with `#land` or `#setland` ([Province Commands](manual/archive/sections/6_map_file_commands/6.7_province_commands.md)).
+
+
 ## Context
 
 The current map model captures terrain, adjacency, and special links but lacks a way to store feature overrides. Without this, user supplied features cannot be represented or written back to a map file. Feature directives also do not round-trip through the parser and renderer, leaving `#setland` and `#feature` lines as pass-through text.

--- a/documentation/engineering/architecture/throne_feature_plan.md
+++ b/documentation/engineering/architecture/throne_feature_plan.md
@@ -39,6 +39,9 @@ This plan describes how to apply throne placements to a map layer using existing
 ## Implementation
 - `ThroneFeatureService` orchestrates the above workflow by loading the map layer, applying throne placements, and writing the result.
 
+## Defender Considerations
+Specific thrones applied through `#feature` do not automatically receive their standard defenders. Populate guardians manually after selecting the province. See [Province Feature Commands](../../domain/dominions/province_features.md#throne-defenders) for details.
+
 ## Alignment with Codebase Principles
 - **Capability Traits** – The plan leans on `ThronePlacementService` and `MapLayerLoader`, respecting the contract/implementation split.
 - **Domain-Driven Types** – `ProvinceId`, `ThroneLevel`, and `ThronePlacement` avoid primitives while modeling the domain clearly.


### PR DESCRIPTION
## Summary
- note that placing a throne with `#feature` does not spawn standard defenders
- reference commander commands for manually adding defenders when using throne features

## Testing
- `sbt compile` *(fails: value util is not a member of com.crib.bills.dom6maps.apps)*

------
https://chatgpt.com/codex/tasks/task_b_68b87c353b548327a45e18cb96559d7e